### PR TITLE
bump documentation.js version, regen docs from latest version

### DIFF
--- a/assets/anchor.js
+++ b/assets/anchor.js
@@ -6,7 +6,7 @@
 /* eslint-env amd, node */
 
 // https://github.com/umdjs/umd/blob/master/templates/returnExports.js
-(function(root, factory) {
+(function (root, factory) {
   'use strict';
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
@@ -21,7 +21,7 @@
     root.AnchorJS = factory();
     root.anchors = new root.AnchorJS();
   }
-})(this, function() {
+})(this, function () {
   'use strict';
   function AnchorJS(options) {
     this.options = options || {};
@@ -51,7 +51,7 @@
      * https://github.com/Modernizr/Modernizr/blob/da22eb27631fc4957f67607fe6042e85c0a84656/feature-detects/touchevents.js#L40
      * @returns {Boolean} - true if the current device supports touch.
      */
-    this.isTouchDevice = function() {
+    this.isTouchDevice = function () {
       return !!(
         'ontouchstart' in window ||
         (window.DocumentTouch && document instanceof DocumentTouch)
@@ -64,7 +64,7 @@
      *                                            to. Also accepts an array or nodeList containing the relavant elements.
      * @returns {this}                           - The AnchorJS object
      */
-    this.add = function(selector) {
+    this.add = function (selector) {
       var elements,
         elsWithIds,
         idList,
@@ -193,7 +193,7 @@
      *                                            OR a nodeList / array containing the DOM elements.
      * @returns {this}                           - The AnchorJS object
      */
-    this.remove = function(selector) {
+    this.remove = function (selector) {
       var index,
         domAnchor,
         elements = _getElements(selector);
@@ -216,7 +216,7 @@
     /**
      * Removes all anchorjs links. Mostly used for tests.
      */
-    this.removeAll = function() {
+    this.removeAll = function () {
       this.remove(this.elements);
     };
 
@@ -229,7 +229,7 @@
      * @param  {String} text - Any text. Usually pulled from the webpage element we are linking to.
      * @returns {String}      - hyphen-delimited text for use in IDs and URLs.
      */
-    this.urlify = function(text) {
+    this.urlify = function (text) {
       // Regex for finding the nonsafe URL characters (many need escaping): & +$,:;=?@"#{}|^~[`%!'<>]./()*\
       var nonsafeChars = /[& +$,:;=?@"#{}|^~[`%!'<>\]\.\/\(\)\*\\]/g,
         urlText;
@@ -260,10 +260,10 @@
      * @param    {HTMLElemnt}  el - a DOM node
      * @returns   {Boolean}     true/false
      */
-    this.hasAnchorJSLink = function(el) {
+    this.hasAnchorJSLink = function (el) {
       var hasLeftAnchor =
-        el.firstChild &&
-        (' ' + el.firstChild.className + ' ').indexOf(' anchorjs-link ') > -1,
+          el.firstChild &&
+          (' ' + el.firstChild.className + ' ').indexOf(' anchorjs-link ') > -1,
         hasRightAnchor =
           el.lastChild &&
           (' ' + el.lastChild.className + ' ').indexOf(' anchorjs-link ') > -1;

--- a/assets/site.js
+++ b/assets/site.js
@@ -7,7 +7,7 @@ anchors.add('h3');
 // Filter UI
 var tocElements = document.getElementById('toc').getElementsByTagName('li');
 
-document.getElementById('filter-input').addEventListener('keyup', function(e) {
+document.getElementById('filter-input').addEventListener('keyup', function (e) {
   var i, element, children;
 
   // enter key
@@ -22,14 +22,14 @@ document.getElementById('filter-input').addEventListener('keyup', function(e) {
     }
   }
 
-  var match = function() {
+  var match = function () {
     return true;
   };
 
   var value = this.value.toLowerCase();
 
   if (!value.match(/^\s*$/)) {
-    match = function(element) {
+    match = function (element) {
       var html = element.firstChild.innerHTML;
       return html && html.toLowerCase().indexOf(value) !== -1;
     };
@@ -114,12 +114,12 @@ var cw_without_sb = split_left.clientWidth;
 split_left.style.overflow = '';
 
 Split(['#split-left', '#split-right'], {
-  elementStyle: function(dimension, size, gutterSize) {
+  elementStyle: function (dimension, size, gutterSize) {
     return {
       'flex-basis': 'calc(' + size + '% - ' + gutterSize + 'px)'
     };
   },
-  gutterStyle: function(dimension, gutterSize) {
+  gutterStyle: function (dimension, gutterSize) {
     return {
       'flex-basis': gutterSize + 'px'
     };
@@ -152,9 +152,9 @@ function loadState(ev) {
   }
 }
 
-window.addEventListener('load', function() {
+window.addEventListener('load', function () {
   // Restore after Firefox scrolls to hash.
-  setTimeout(function() {
+  setTimeout(function () {
     loadState();
     // Update with initial scroll position.
     updateState();

--- a/assets/split.js
+++ b/assets/split.js
@@ -1,586 +1,782 @@
-/*! Split.js - v1.3.5 */
-// https://github.com/nathancahill/Split.js
-// Copyright (c) 2017 Nathan Cahill; Licensed MIT
+/*! Split.js - v1.5.11 */
 
-(function(global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined'
-    ? (module.exports = factory())
-    : typeof define === 'function' && define.amd
-      ? define(factory)
-      : (global.Split = factory());
-})(this, function() {
-  'use strict';
-  // The programming goals of Split.js are to deliver readable, understandable and
-  // maintainable code, while at the same time manually optimizing for tiny minified file size,
-  // browser compatibility without additional requirements, graceful fallback (IE8 is supported)
-  // and very few assumptions about the user's page layout.
-  var global = window;
-  var document = global.document;
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+    typeof define === 'function' && define.amd ? define(factory) :
+    (global.Split = factory());
+}(this, (function () { 'use strict';
 
-  // Save a couple long function names that are used frequently.
-  // This optimization saves around 400 bytes.
-  var addEventListener = 'addEventListener';
-  var removeEventListener = 'removeEventListener';
-  var getBoundingClientRect = 'getBoundingClientRect';
-  var NOOP = function() {
-    return false;
-  };
+    // The programming goals of Split.js are to deliver readable, understandable and
+    // maintainable code, while at the same time manually optimizing for tiny minified file size,
+    // browser compatibility without additional requirements, graceful fallback (IE8 is supported)
+    // and very few assumptions about the user's page layout.
+    var global = window;
+    var document = global.document;
 
-  // Figure out if we're in IE8 or not. IE8 will still render correctly,
-  // but will be static instead of draggable.
-  var isIE8 = global.attachEvent && !global[addEventListener];
+    // Save a couple long function names that are used frequently.
+    // This optimization saves around 400 bytes.
+    var addEventListener = 'addEventListener';
+    var removeEventListener = 'removeEventListener';
+    var getBoundingClientRect = 'getBoundingClientRect';
+    var gutterStartDragging = '_a';
+    var aGutterSize = '_b';
+    var bGutterSize = '_c';
+    var HORIZONTAL = 'horizontal';
+    var NOOP = function () { return false; };
 
-  // This library only needs two helper functions:
-  //
-  // The first determines which prefixes of CSS calc we need.
-  // We only need to do this once on startup, when this anonymous function is called.
-  //
-  // Tests -webkit, -moz and -o prefixes. Modified from StackOverflow:
-  // http://stackoverflow.com/questions/16625140/js-feature-detection-to-detect-the-usage-of-webkit-calc-over-calc/16625167#16625167
-  var calc =
-    ['', '-webkit-', '-moz-', '-o-']
-      .filter(function(prefix) {
-        var el = document.createElement('div');
-        el.style.cssText = 'width:' + prefix + 'calc(9px)';
+    // Figure out if we're in IE8 or not. IE8 will still render correctly,
+    // but will be static instead of draggable.
+    var isIE8 = global.attachEvent && !global[addEventListener];
 
-        return !!el.style.length;
-      })
-      .shift() + 'calc';
+    // Helper function determines which prefixes of CSS calc we need.
+    // We only need to do this once on startup, when this anonymous function is called.
+    //
+    // Tests -webkit, -moz and -o prefixes. Modified from StackOverflow:
+    // http://stackoverflow.com/questions/16625140/js-feature-detection-to-detect-the-usage-of-webkit-calc-over-calc/16625167#16625167
+    var calc = (['', '-webkit-', '-moz-', '-o-']
+        .filter(function (prefix) {
+            var el = document.createElement('div');
+            el.style.cssText = "width:" + prefix + "calc(9px)";
 
-  // The second helper function allows elements and string selectors to be used
-  // interchangeably. In either case an element is returned. This allows us to
-  // do `Split([elem1, elem2])` as well as `Split(['#id1', '#id2'])`.
-  var elementOrSelector = function(el) {
-    if (typeof el === 'string' || el instanceof String) {
-      return document.querySelector(el);
-    }
+            return !!el.style.length
+        })
+        .shift()) + "calc";
 
-    return el;
-  };
+    // Helper function checks if its argument is a string-like type
+    var isString = function (v) { return typeof v === 'string' || v instanceof String; };
 
-  // The main function to initialize a split. Split.js thinks about each pair
-  // of elements as an independant pair. Dragging the gutter between two elements
-  // only changes the dimensions of elements in that pair. This is key to understanding
-  // how the following functions operate, since each function is bound to a pair.
-  //
-  // A pair object is shaped like this:
-  //
-  // {
-  //     a: DOM element,
-  //     b: DOM element,
-  //     aMin: Number,
-  //     bMin: Number,
-  //     dragging: Boolean,
-  //     parent: DOM element,
-  //     isFirst: Boolean,
-  //     isLast: Boolean,
-  //     direction: 'horizontal' | 'vertical'
-  // }
-  //
-  // The basic sequence:
-  //
-  // 1. Set defaults to something sane. `options` doesn't have to be passed at all.
-  // 2. Initialize a bunch of strings based on the direction we're splitting.
-  //    A lot of the behavior in the rest of the library is paramatized down to
-  //    rely on CSS strings and classes.
-  // 3. Define the dragging helper functions, and a few helpers to go with them.
-  // 4. Loop through the elements while pairing them off. Every pair gets an
-  //    `pair` object, a gutter, and special isFirst/isLast properties.
-  // 5. Actually size the pair elements, insert gutters and attach event listeners.
-  var Split = function(ids, options) {
-    if (options === void 0) options = {};
+    // Helper function allows elements and string selectors to be used
+    // interchangeably. In either case an element is returned. This allows us to
+    // do `Split([elem1, elem2])` as well as `Split(['#id1', '#id2'])`.
+    var elementOrSelector = function (el) {
+        if (isString(el)) {
+            var ele = document.querySelector(el);
+            if (!ele) {
+                throw new Error(("Selector " + el + " did not match a DOM element"))
+            }
+            return ele
+        }
 
-    var dimension;
-    var clientDimension;
-    var clientAxis;
-    var position;
-    var paddingA;
-    var paddingB;
-    var elements;
+        return el
+    };
 
-    // All DOM elements in the split should have a common parent. We can grab
-    // the first elements parent and hope users read the docs because the
-    // behavior will be whacky otherwise.
-    var parent = elementOrSelector(ids[0]).parentNode;
-    var parentFlexDirection = global.getComputedStyle(parent).flexDirection;
+    // Helper function gets a property from the properties object, with a default fallback
+    var getOption = function (options, propName, def) {
+        var value = options[propName];
+        if (value !== undefined) {
+            return value
+        }
+        return def
+    };
 
-    // Set default options.sizes to equal percentages of the parent element.
-    var sizes =
-      options.sizes ||
-      ids.map(function() {
-        return 100 / ids.length;
-      });
+    var getGutterSize = function (gutterSize, isFirst, isLast, gutterAlign) {
+        if (isFirst) {
+            if (gutterAlign === 'end') {
+                return 0
+            }
+            if (gutterAlign === 'center') {
+                return gutterSize / 2
+            }
+        } else if (isLast) {
+            if (gutterAlign === 'start') {
+                return 0
+            }
+            if (gutterAlign === 'center') {
+                return gutterSize / 2
+            }
+        }
 
-    // Standardize minSize to an array if it isn't already. This allows minSize
-    // to be passed as a number.
-    var minSize = options.minSize !== undefined ? options.minSize : 100;
-    var minSizes = Array.isArray(minSize)
-      ? minSize
-      : ids.map(function() {
-          return minSize;
-        });
-    var gutterSize = options.gutterSize !== undefined ? options.gutterSize : 10;
-    var snapOffset = options.snapOffset !== undefined ? options.snapOffset : 30;
-    var direction = options.direction || 'horizontal';
-    var cursor =
-      options.cursor ||
-      (direction === 'horizontal' ? 'ew-resize' : 'ns-resize');
-    var gutter =
-      options.gutter ||
-      function(i, gutterDirection) {
+        return gutterSize
+    };
+
+    // Default options
+    var defaultGutterFn = function (i, gutterDirection) {
         var gut = document.createElement('div');
-        gut.className = 'gutter gutter-' + gutterDirection;
-        return gut;
-      };
-    var elementStyle =
-      options.elementStyle ||
-      function(dim, size, gutSize) {
+        gut.className = "gutter gutter-" + gutterDirection;
+        return gut
+    };
+
+    var defaultElementStyleFn = function (dim, size, gutSize) {
         var style = {};
 
-        if (typeof size !== 'string' && !(size instanceof String)) {
-          if (!isIE8) {
-            style[dim] = calc + '(' + size + '% - ' + gutSize + 'px)';
-          } else {
-            style[dim] = size + '%';
-          }
+        if (!isString(size)) {
+            if (!isIE8) {
+                style[dim] = calc + "(" + size + "% - " + gutSize + "px)";
+            } else {
+                style[dim] = size + "%";
+            }
         } else {
-          style[dim] = size;
+            style[dim] = size;
         }
 
-        return style;
-      };
-    var gutterStyle =
-      options.gutterStyle ||
-      function(dim, gutSize) {
-        return (obj = {}), (obj[dim] = gutSize + 'px'), obj;
-        var obj;
-      };
-
-    // 2. Initialize a bunch of strings based on the direction we're splitting.
-    // A lot of the behavior in the rest of the library is paramatized down to
-    // rely on CSS strings and classes.
-    if (direction === 'horizontal') {
-      dimension = 'width';
-      clientDimension = 'clientWidth';
-      clientAxis = 'clientX';
-      position = 'left';
-      paddingA = 'paddingLeft';
-      paddingB = 'paddingRight';
-    } else if (direction === 'vertical') {
-      dimension = 'height';
-      clientDimension = 'clientHeight';
-      clientAxis = 'clientY';
-      position = 'top';
-      paddingA = 'paddingTop';
-      paddingB = 'paddingBottom';
-    }
-
-    // 3. Define the dragging helper functions, and a few helpers to go with them.
-    // Each helper is bound to a pair object that contains it's metadata. This
-    // also makes it easy to store references to listeners that that will be
-    // added and removed.
-    //
-    // Even though there are no other functions contained in them, aliasing
-    // this to self saves 50 bytes or so since it's used so frequently.
-    //
-    // The pair object saves metadata like dragging state, position and
-    // event listener references.
-
-    function setElementSize(el, size, gutSize) {
-      // Split.js allows setting sizes via numbers (ideally), or if you must,
-      // by string, like '300px'. This is less than ideal, because it breaks
-      // the fluid layout that `calc(% - px)` provides. You're on your own if you do that,
-      // make sure you calculate the gutter size by hand.
-      var style = elementStyle(dimension, size, gutSize);
-
-      // eslint-disable-next-line no-param-reassign
-      Object.keys(style).forEach(function(prop) {
-        return (el.style[prop] = style[prop]);
-      });
-    }
-
-    function setGutterSize(gutterElement, gutSize) {
-      var style = gutterStyle(dimension, gutSize);
-
-      // eslint-disable-next-line no-param-reassign
-      Object.keys(style).forEach(function(prop) {
-        return (gutterElement.style[prop] = style[prop]);
-      });
-    }
-
-    // Actually adjust the size of elements `a` and `b` to `offset` while dragging.
-    // calc is used to allow calc(percentage + gutterpx) on the whole split instance,
-    // which allows the viewport to be resized without additional logic.
-    // Element a's size is the same as offset. b's size is total size - a size.
-    // Both sizes are calculated from the initial parent percentage,
-    // then the gutter size is subtracted.
-    function adjust(offset) {
-      var a = elements[this.a];
-      var b = elements[this.b];
-      var percentage = a.size + b.size;
-
-      a.size = offset / this.size * percentage;
-      b.size = percentage - offset / this.size * percentage;
-
-      setElementSize(a.element, a.size, this.aGutterSize);
-      setElementSize(b.element, b.size, this.bGutterSize);
-    }
-
-    // drag, where all the magic happens. The logic is really quite simple:
-    //
-    // 1. Ignore if the pair is not dragging.
-    // 2. Get the offset of the event.
-    // 3. Snap offset to min if within snappable range (within min + snapOffset).
-    // 4. Actually adjust each element in the pair to offset.
-    //
-    // ---------------------------------------------------------------------
-    // |    | <- a.minSize               ||              b.minSize -> |    |
-    // |    |  | <- this.snapOffset      ||     this.snapOffset -> |  |    |
-    // |    |  |                         ||                        |  |    |
-    // |    |  |                         ||                        |  |    |
-    // ---------------------------------------------------------------------
-    // | <- this.start                                        this.size -> |
-    function drag(e) {
-      var offset;
-
-      if (!this.dragging) {
-        return;
-      }
-
-      // Get the offset of the event from the first side of the
-      // pair `this.start`. Supports touch events, but not multitouch, so only the first
-      // finger `touches[0]` is counted.
-      if ('touches' in e) {
-        offset = e.touches[0][clientAxis] - this.start;
-      } else {
-        offset = e[clientAxis] - this.start;
-      }
-
-      // If within snapOffset of min or max, set offset to min or max.
-      // snapOffset buffers a.minSize and b.minSize, so logic is opposite for both.
-      // Include the appropriate gutter sizes to prevent overflows.
-      if (offset <= elements[this.a].minSize + snapOffset + this.aGutterSize) {
-        offset = elements[this.a].minSize + this.aGutterSize;
-      } else if (
-        offset >=
-        this.size - (elements[this.b].minSize + snapOffset + this.bGutterSize)
-      ) {
-        offset = this.size - (elements[this.b].minSize + this.bGutterSize);
-      }
-
-      // Actually adjust the size.
-      adjust.call(this, offset);
-
-      // Call the drag callback continously. Don't do anything too intensive
-      // in this callback.
-      if (options.onDrag) {
-        options.onDrag();
-      }
-    }
-
-    // Cache some important sizes when drag starts, so we don't have to do that
-    // continously:
-    //
-    // `size`: The total size of the pair. First + second + first gutter + second gutter.
-    // `start`: The leading side of the first element.
-    //
-    // ------------------------------------------------
-    // |      aGutterSize -> |||                      |
-    // |                     |||                      |
-    // |                     |||                      |
-    // |                     ||| <- bGutterSize       |
-    // ------------------------------------------------
-    // | <- start                             size -> |
-    function calculateSizes() {
-      // Figure out the parent size minus padding.
-      var a = elements[this.a].element;
-      var b = elements[this.b].element;
-
-      this.size =
-        a[getBoundingClientRect]()[dimension] +
-        b[getBoundingClientRect]()[dimension] +
-        this.aGutterSize +
-        this.bGutterSize;
-      this.start = a[getBoundingClientRect]()[position];
-    }
-
-    // stopDragging is very similar to startDragging in reverse.
-    function stopDragging() {
-      var self = this;
-      var a = elements[self.a].element;
-      var b = elements[self.b].element;
-
-      if (self.dragging && options.onDragEnd) {
-        options.onDragEnd();
-      }
-
-      self.dragging = false;
-
-      // Remove the stored event listeners. This is why we store them.
-      global[removeEventListener]('mouseup', self.stop);
-      global[removeEventListener]('touchend', self.stop);
-      global[removeEventListener]('touchcancel', self.stop);
-
-      self.parent[removeEventListener]('mousemove', self.move);
-      self.parent[removeEventListener]('touchmove', self.move);
-
-      // Delete them once they are removed. I think this makes a difference
-      // in memory usage with a lot of splits on one page. But I don't know for sure.
-      delete self.stop;
-      delete self.move;
-
-      a[removeEventListener]('selectstart', NOOP);
-      a[removeEventListener]('dragstart', NOOP);
-      b[removeEventListener]('selectstart', NOOP);
-      b[removeEventListener]('dragstart', NOOP);
-
-      a.style.userSelect = '';
-      a.style.webkitUserSelect = '';
-      a.style.MozUserSelect = '';
-      a.style.pointerEvents = '';
-
-      b.style.userSelect = '';
-      b.style.webkitUserSelect = '';
-      b.style.MozUserSelect = '';
-      b.style.pointerEvents = '';
-
-      self.gutter.style.cursor = '';
-      self.parent.style.cursor = '';
-    }
-
-    // startDragging calls `calculateSizes` to store the inital size in the pair object.
-    // It also adds event listeners for mouse/touch events,
-    // and prevents selection while dragging so avoid the selecting text.
-    function startDragging(e) {
-      // Alias frequently used variables to save space. 200 bytes.
-      var self = this;
-      var a = elements[self.a].element;
-      var b = elements[self.b].element;
-
-      // Call the onDragStart callback.
-      if (!self.dragging && options.onDragStart) {
-        options.onDragStart();
-      }
-
-      // Don't actually drag the element. We emulate that in the drag function.
-      e.preventDefault();
-
-      // Set the dragging property of the pair object.
-      self.dragging = true;
-
-      // Create two event listeners bound to the same pair object and store
-      // them in the pair object.
-      self.move = drag.bind(self);
-      self.stop = stopDragging.bind(self);
-
-      // All the binding. `window` gets the stop events in case we drag out of the elements.
-      global[addEventListener]('mouseup', self.stop);
-      global[addEventListener]('touchend', self.stop);
-      global[addEventListener]('touchcancel', self.stop);
-
-      self.parent[addEventListener]('mousemove', self.move);
-      self.parent[addEventListener]('touchmove', self.move);
-
-      // Disable selection. Disable!
-      a[addEventListener]('selectstart', NOOP);
-      a[addEventListener]('dragstart', NOOP);
-      b[addEventListener]('selectstart', NOOP);
-      b[addEventListener]('dragstart', NOOP);
-
-      a.style.userSelect = 'none';
-      a.style.webkitUserSelect = 'none';
-      a.style.MozUserSelect = 'none';
-      a.style.pointerEvents = 'none';
-
-      b.style.userSelect = 'none';
-      b.style.webkitUserSelect = 'none';
-      b.style.MozUserSelect = 'none';
-      b.style.pointerEvents = 'none';
-
-      // Set the cursor, both on the gutter and the parent element.
-      // Doing only a, b and gutter causes flickering.
-      self.gutter.style.cursor = cursor;
-      self.parent.style.cursor = cursor;
-
-      // Cache the initial sizes of the pair.
-      calculateSizes.call(self);
-    }
-
-    // 5. Create pair and element objects. Each pair has an index reference to
-    // elements `a` and `b` of the pair (first and second elements).
-    // Loop through the elements while pairing them off. Every pair gets a
-    // `pair` object, a gutter, and isFirst/isLast properties.
-    //
-    // Basic logic:
-    //
-    // - Starting with the second element `i > 0`, create `pair` objects with
-    //   `a = i - 1` and `b = i`
-    // - Set gutter sizes based on the _pair_ being first/last. The first and last
-    //   pair have gutterSize / 2, since they only have one half gutter, and not two.
-    // - Create gutter elements and add event listeners.
-    // - Set the size of the elements, minus the gutter sizes.
-    //
-    // -----------------------------------------------------------------------
-    // |     i=0     |         i=1         |        i=2       |      i=3     |
-    // |             |       isFirst       |                  |     isLast   |
-    // |           pair 0                pair 1             pair 2           |
-    // |             |                     |                  |              |
-    // -----------------------------------------------------------------------
-    var pairs = [];
-    elements = ids.map(function(id, i) {
-      // Create the element object.
-      var element = {
-        element: elementOrSelector(id),
-        size: sizes[i],
-        minSize: minSizes[i]
-      };
-
-      var pair;
-
-      if (i > 0) {
-        // Create the pair object with it's metadata.
-        pair = {
-          a: i - 1,
-          b: i,
-          dragging: false,
-          isFirst: i === 1,
-          isLast: i === ids.length - 1,
-          direction: direction,
-          parent: parent
-        };
-
-        // For first and last pairs, first and last gutter width is half.
-        pair.aGutterSize = gutterSize;
-        pair.bGutterSize = gutterSize;
-
-        if (pair.isFirst) {
-          pair.aGutterSize = gutterSize / 2;
-        }
-
-        if (pair.isLast) {
-          pair.bGutterSize = gutterSize / 2;
-        }
-
-        // if the parent has a reverse flex-direction, switch the pair elements.
-        if (
-          parentFlexDirection === 'row-reverse' ||
-          parentFlexDirection === 'column-reverse'
-        ) {
-          var temp = pair.a;
-          pair.a = pair.b;
-          pair.b = temp;
-        }
-      }
-
-      // Determine the size of the current element. IE8 is supported by
-      // staticly assigning sizes without draggable gutters. Assigns a string
-      // to `size`.
-      //
-      // IE9 and above
-      if (!isIE8) {
-        // Create gutter elements for each pair.
-        if (i > 0) {
-          var gutterElement = gutter(i, direction);
-          setGutterSize(gutterElement, gutterSize);
-
-          gutterElement[addEventListener](
-            'mousedown',
-            startDragging.bind(pair)
-          );
-          gutterElement[addEventListener](
-            'touchstart',
-            startDragging.bind(pair)
-          );
-
-          parent.insertBefore(gutterElement, element.element);
-
-          pair.gutter = gutterElement;
-        }
-      }
-
-      // Set the element size to our determined size.
-      // Half-size gutters for first and last elements.
-      if (i === 0 || i === ids.length - 1) {
-        setElementSize(element.element, element.size, gutterSize / 2);
-      } else {
-        setElementSize(element.element, element.size, gutterSize);
-      }
-
-      var computedSize = element.element[getBoundingClientRect]()[dimension];
-
-      if (computedSize < element.minSize) {
-        element.minSize = computedSize;
-      }
-
-      // After the first iteration, and we have a pair object, append it to the
-      // list of pairs.
-      if (i > 0) {
-        pairs.push(pair);
-      }
-
-      return element;
-    });
-
-    function setSizes(newSizes) {
-      newSizes.forEach(function(newSize, i) {
-        if (i > 0) {
-          var pair = pairs[i - 1];
-          var a = elements[pair.a];
-          var b = elements[pair.b];
-
-          a.size = newSizes[i - 1];
-          b.size = newSize;
-
-          setElementSize(a.element, a.size, pair.aGutterSize);
-          setElementSize(b.element, b.size, pair.bGutterSize);
-        }
-      });
-    }
-
-    function destroy() {
-      pairs.forEach(function(pair) {
-        pair.parent.removeChild(pair.gutter);
-        elements[pair.a].element.style[dimension] = '';
-        elements[pair.b].element.style[dimension] = '';
-      });
-    }
-
-    if (isIE8) {
-      return {
-        setSizes: setSizes,
-        destroy: destroy
-      };
-    }
-
-    return {
-      setSizes: setSizes,
-      getSizes: function getSizes() {
-        return elements.map(function(element) {
-          return element.size;
-        });
-      },
-      collapse: function collapse(i) {
-        if (i === pairs.length) {
-          var pair = pairs[i - 1];
-
-          calculateSizes.call(pair);
-
-          if (!isIE8) {
-            adjust.call(pair, pair.size - pair.bGutterSize);
-          }
-        } else {
-          var pair$1 = pairs[i];
-
-          calculateSizes.call(pair$1);
-
-          if (!isIE8) {
-            adjust.call(pair$1, pair$1.aGutterSize);
-          }
-        }
-      },
-      destroy: destroy
+        return style
     };
-  };
 
-  return Split;
-});
+    var defaultGutterStyleFn = function (dim, gutSize) {
+        var obj;
+
+        return (( obj = {}, obj[dim] = (gutSize + "px"), obj ));
+    };
+
+    // The main function to initialize a split. Split.js thinks about each pair
+    // of elements as an independant pair. Dragging the gutter between two elements
+    // only changes the dimensions of elements in that pair. This is key to understanding
+    // how the following functions operate, since each function is bound to a pair.
+    //
+    // A pair object is shaped like this:
+    //
+    // {
+    //     a: DOM element,
+    //     b: DOM element,
+    //     aMin: Number,
+    //     bMin: Number,
+    //     dragging: Boolean,
+    //     parent: DOM element,
+    //     direction: 'horizontal' | 'vertical'
+    // }
+    //
+    // The basic sequence:
+    //
+    // 1. Set defaults to something sane. `options` doesn't have to be passed at all.
+    // 2. Initialize a bunch of strings based on the direction we're splitting.
+    //    A lot of the behavior in the rest of the library is paramatized down to
+    //    rely on CSS strings and classes.
+    // 3. Define the dragging helper functions, and a few helpers to go with them.
+    // 4. Loop through the elements while pairing them off. Every pair gets an
+    //    `pair` object and a gutter.
+    // 5. Actually size the pair elements, insert gutters and attach event listeners.
+    var Split = function (idsOption, options) {
+        if ( options === void 0 ) options = {};
+
+        var ids = idsOption;
+        var dimension;
+        var clientAxis;
+        var position;
+        var positionEnd;
+        var clientSize;
+        var elements;
+
+        // Allow HTMLCollection to be used as an argument when supported
+        if (Array.from) {
+            ids = Array.from(ids);
+        }
+
+        // All DOM elements in the split should have a common parent. We can grab
+        // the first elements parent and hope users read the docs because the
+        // behavior will be whacky otherwise.
+        var firstElement = elementOrSelector(ids[0]);
+        var parent = firstElement.parentNode;
+        var parentStyle = getComputedStyle ? getComputedStyle(parent) : null;
+        var parentFlexDirection = parentStyle ? parentStyle.flexDirection : null;
+
+        // Set default options.sizes to equal percentages of the parent element.
+        var sizes = getOption(options, 'sizes') || ids.map(function () { return 100 / ids.length; });
+
+        // Standardize minSize to an array if it isn't already. This allows minSize
+        // to be passed as a number.
+        var minSize = getOption(options, 'minSize', 100);
+        var minSizes = Array.isArray(minSize) ? minSize : ids.map(function () { return minSize; });
+
+        // Get other options
+        var expandToMin = getOption(options, 'expandToMin', false);
+        var gutterSize = getOption(options, 'gutterSize', 10);
+        var gutterAlign = getOption(options, 'gutterAlign', 'center');
+        var snapOffset = getOption(options, 'snapOffset', 30);
+        var dragInterval = getOption(options, 'dragInterval', 1);
+        var direction = getOption(options, 'direction', HORIZONTAL);
+        var cursor = getOption(
+            options,
+            'cursor',
+            direction === HORIZONTAL ? 'col-resize' : 'row-resize'
+        );
+        var gutter = getOption(options, 'gutter', defaultGutterFn);
+        var elementStyle = getOption(
+            options,
+            'elementStyle',
+            defaultElementStyleFn
+        );
+        var gutterStyle = getOption(options, 'gutterStyle', defaultGutterStyleFn);
+
+        // 2. Initialize a bunch of strings based on the direction we're splitting.
+        // A lot of the behavior in the rest of the library is paramatized down to
+        // rely on CSS strings and classes.
+        if (direction === HORIZONTAL) {
+            dimension = 'width';
+            clientAxis = 'clientX';
+            position = 'left';
+            positionEnd = 'right';
+            clientSize = 'clientWidth';
+        } else if (direction === 'vertical') {
+            dimension = 'height';
+            clientAxis = 'clientY';
+            position = 'top';
+            positionEnd = 'bottom';
+            clientSize = 'clientHeight';
+        }
+
+        // 3. Define the dragging helper functions, and a few helpers to go with them.
+        // Each helper is bound to a pair object that contains its metadata. This
+        // also makes it easy to store references to listeners that that will be
+        // added and removed.
+        //
+        // Even though there are no other functions contained in them, aliasing
+        // this to self saves 50 bytes or so since it's used so frequently.
+        //
+        // The pair object saves metadata like dragging state, position and
+        // event listener references.
+
+        function setElementSize(el, size, gutSize, i) {
+            // Split.js allows setting sizes via numbers (ideally), or if you must,
+            // by string, like '300px'. This is less than ideal, because it breaks
+            // the fluid layout that `calc(% - px)` provides. You're on your own if you do that,
+            // make sure you calculate the gutter size by hand.
+            var style = elementStyle(dimension, size, gutSize, i);
+
+            Object.keys(style).forEach(function (prop) {
+                // eslint-disable-next-line no-param-reassign
+                el.style[prop] = style[prop];
+            });
+        }
+
+        function setGutterSize(gutterElement, gutSize, i) {
+            var style = gutterStyle(dimension, gutSize, i);
+
+            Object.keys(style).forEach(function (prop) {
+                // eslint-disable-next-line no-param-reassign
+                gutterElement.style[prop] = style[prop];
+            });
+        }
+
+        function getSizes() {
+            return elements.map(function (element) { return element.size; })
+        }
+
+        // Supports touch events, but not multitouch, so only the first
+        // finger `touches[0]` is counted.
+        function getMousePosition(e) {
+            if ('touches' in e) { return e.touches[0][clientAxis] }
+            return e[clientAxis]
+        }
+
+        // Actually adjust the size of elements `a` and `b` to `offset` while dragging.
+        // calc is used to allow calc(percentage + gutterpx) on the whole split instance,
+        // which allows the viewport to be resized without additional logic.
+        // Element a's size is the same as offset. b's size is total size - a size.
+        // Both sizes are calculated from the initial parent percentage,
+        // then the gutter size is subtracted.
+        function adjust(offset) {
+            var a = elements[this.a];
+            var b = elements[this.b];
+            var percentage = a.size + b.size;
+
+            a.size = (offset / this.size) * percentage;
+            b.size = percentage - (offset / this.size) * percentage;
+
+            setElementSize(a.element, a.size, this[aGutterSize], a.i);
+            setElementSize(b.element, b.size, this[bGutterSize], b.i);
+        }
+
+        // drag, where all the magic happens. The logic is really quite simple:
+        //
+        // 1. Ignore if the pair is not dragging.
+        // 2. Get the offset of the event.
+        // 3. Snap offset to min if within snappable range (within min + snapOffset).
+        // 4. Actually adjust each element in the pair to offset.
+        //
+        // ---------------------------------------------------------------------
+        // |    | <- a.minSize               ||              b.minSize -> |    |
+        // |    |  | <- this.snapOffset      ||     this.snapOffset -> |  |    |
+        // |    |  |                         ||                        |  |    |
+        // |    |  |                         ||                        |  |    |
+        // ---------------------------------------------------------------------
+        // | <- this.start                                        this.size -> |
+        function drag(e) {
+            var offset;
+            var a = elements[this.a];
+            var b = elements[this.b];
+
+            if (!this.dragging) { return }
+
+            // Get the offset of the event from the first side of the
+            // pair `this.start`. Then offset by the initial position of the
+            // mouse compared to the gutter size.
+            offset =
+                getMousePosition(e) -
+                this.start +
+                (this[aGutterSize] - this.dragOffset);
+
+            if (dragInterval > 1) {
+                offset = Math.round(offset / dragInterval) * dragInterval;
+            }
+
+            // If within snapOffset of min or max, set offset to min or max.
+            // snapOffset buffers a.minSize and b.minSize, so logic is opposite for both.
+            // Include the appropriate gutter sizes to prevent overflows.
+            if (offset <= a.minSize + snapOffset + this[aGutterSize]) {
+                offset = a.minSize + this[aGutterSize];
+            } else if (
+                offset >=
+                this.size - (b.minSize + snapOffset + this[bGutterSize])
+            ) {
+                offset = this.size - (b.minSize + this[bGutterSize]);
+            }
+
+            // Actually adjust the size.
+            adjust.call(this, offset);
+
+            // Call the drag callback continously. Don't do anything too intensive
+            // in this callback.
+            getOption(options, 'onDrag', NOOP)();
+        }
+
+        // Cache some important sizes when drag starts, so we don't have to do that
+        // continously:
+        //
+        // `size`: The total size of the pair. First + second + first gutter + second gutter.
+        // `start`: The leading side of the first element.
+        //
+        // ------------------------------------------------
+        // |      aGutterSize -> |||                      |
+        // |                     |||                      |
+        // |                     |||                      |
+        // |                     ||| <- bGutterSize       |
+        // ------------------------------------------------
+        // | <- start                             size -> |
+        function calculateSizes() {
+            // Figure out the parent size minus padding.
+            var a = elements[this.a].element;
+            var b = elements[this.b].element;
+
+            var aBounds = a[getBoundingClientRect]();
+            var bBounds = b[getBoundingClientRect]();
+
+            this.size =
+                aBounds[dimension] +
+                bBounds[dimension] +
+                this[aGutterSize] +
+                this[bGutterSize];
+            this.start = aBounds[position];
+            this.end = aBounds[positionEnd];
+        }
+
+        function innerSize(element) {
+            // Return nothing if getComputedStyle is not supported (< IE9)
+            // Or if parent element has no layout yet
+            if (!getComputedStyle) { return null }
+
+            var computedStyle = getComputedStyle(element);
+
+            if (!computedStyle) { return null }
+
+            var size = element[clientSize];
+
+            if (size === 0) { return null }
+
+            if (direction === HORIZONTAL) {
+                size -=
+                    parseFloat(computedStyle.paddingLeft) +
+                    parseFloat(computedStyle.paddingRight);
+            } else {
+                size -=
+                    parseFloat(computedStyle.paddingTop) +
+                    parseFloat(computedStyle.paddingBottom);
+            }
+
+            return size
+        }
+
+        // When specifying percentage sizes that are less than the computed
+        // size of the element minus the gutter, the lesser percentages must be increased
+        // (and decreased from the other elements) to make space for the pixels
+        // subtracted by the gutters.
+        function trimToMin(sizesToTrim) {
+            // Try to get inner size of parent element.
+            // If it's no supported, return original sizes.
+            var parentSize = innerSize(parent);
+            if (parentSize === null) {
+                return sizesToTrim
+            }
+
+            if (minSizes.reduce(function (a, b) { return a + b; }, 0) > parentSize) {
+                return sizesToTrim
+            }
+
+            // Keep track of the excess pixels, the amount of pixels over the desired percentage
+            // Also keep track of the elements with pixels to spare, to decrease after if needed
+            var excessPixels = 0;
+            var toSpare = [];
+
+            var pixelSizes = sizesToTrim.map(function (size, i) {
+                // Convert requested percentages to pixel sizes
+                var pixelSize = (parentSize * size) / 100;
+                var elementGutterSize = getGutterSize(
+                    gutterSize,
+                    i === 0,
+                    i === sizesToTrim.length - 1,
+                    gutterAlign
+                );
+                var elementMinSize = minSizes[i] + elementGutterSize;
+
+                // If element is too smal, increase excess pixels by the difference
+                // and mark that it has no pixels to spare
+                if (pixelSize < elementMinSize) {
+                    excessPixels += elementMinSize - pixelSize;
+                    toSpare.push(0);
+                    return elementMinSize
+                }
+
+                // Otherwise, mark the pixels it has to spare and return it's original size
+                toSpare.push(pixelSize - elementMinSize);
+                return pixelSize
+            });
+
+            // If nothing was adjusted, return the original sizes
+            if (excessPixels === 0) {
+                return sizesToTrim
+            }
+
+            return pixelSizes.map(function (pixelSize, i) {
+                var newPixelSize = pixelSize;
+
+                // While there's still pixels to take, and there's enough pixels to spare,
+                // take as many as possible up to the total excess pixels
+                if (excessPixels > 0 && toSpare[i] - excessPixels > 0) {
+                    var takenPixels = Math.min(
+                        excessPixels,
+                        toSpare[i] - excessPixels
+                    );
+
+                    // Subtract the amount taken for the next iteration
+                    excessPixels -= takenPixels;
+                    newPixelSize = pixelSize - takenPixels;
+                }
+
+                // Return the pixel size adjusted as a percentage
+                return (newPixelSize / parentSize) * 100
+            })
+        }
+
+        // stopDragging is very similar to startDragging in reverse.
+        function stopDragging() {
+            var self = this;
+            var a = elements[self.a].element;
+            var b = elements[self.b].element;
+
+            if (self.dragging) {
+                getOption(options, 'onDragEnd', NOOP)(getSizes());
+            }
+
+            self.dragging = false;
+
+            // Remove the stored event listeners. This is why we store them.
+            global[removeEventListener]('mouseup', self.stop);
+            global[removeEventListener]('touchend', self.stop);
+            global[removeEventListener]('touchcancel', self.stop);
+            global[removeEventListener]('mousemove', self.move);
+            global[removeEventListener]('touchmove', self.move);
+
+            // Clear bound function references
+            self.stop = null;
+            self.move = null;
+
+            a[removeEventListener]('selectstart', NOOP);
+            a[removeEventListener]('dragstart', NOOP);
+            b[removeEventListener]('selectstart', NOOP);
+            b[removeEventListener]('dragstart', NOOP);
+
+            a.style.userSelect = '';
+            a.style.webkitUserSelect = '';
+            a.style.MozUserSelect = '';
+            a.style.pointerEvents = '';
+
+            b.style.userSelect = '';
+            b.style.webkitUserSelect = '';
+            b.style.MozUserSelect = '';
+            b.style.pointerEvents = '';
+
+            self.gutter.style.cursor = '';
+            self.parent.style.cursor = '';
+            document.body.style.cursor = '';
+        }
+
+        // startDragging calls `calculateSizes` to store the inital size in the pair object.
+        // It also adds event listeners for mouse/touch events,
+        // and prevents selection while dragging so avoid the selecting text.
+        function startDragging(e) {
+            // Right-clicking can't start dragging.
+            if ('button' in e && e.button !== 0) {
+                return
+            }
+
+            // Alias frequently used variables to save space. 200 bytes.
+            var self = this;
+            var a = elements[self.a].element;
+            var b = elements[self.b].element;
+
+            // Call the onDragStart callback.
+            if (!self.dragging) {
+                getOption(options, 'onDragStart', NOOP)(getSizes());
+            }
+
+            // Don't actually drag the element. We emulate that in the drag function.
+            e.preventDefault();
+
+            // Set the dragging property of the pair object.
+            self.dragging = true;
+
+            // Create two event listeners bound to the same pair object and store
+            // them in the pair object.
+            self.move = drag.bind(self);
+            self.stop = stopDragging.bind(self);
+
+            // All the binding. `window` gets the stop events in case we drag out of the elements.
+            global[addEventListener]('mouseup', self.stop);
+            global[addEventListener]('touchend', self.stop);
+            global[addEventListener]('touchcancel', self.stop);
+            global[addEventListener]('mousemove', self.move);
+            global[addEventListener]('touchmove', self.move);
+
+            // Disable selection. Disable!
+            a[addEventListener]('selectstart', NOOP);
+            a[addEventListener]('dragstart', NOOP);
+            b[addEventListener]('selectstart', NOOP);
+            b[addEventListener]('dragstart', NOOP);
+
+            a.style.userSelect = 'none';
+            a.style.webkitUserSelect = 'none';
+            a.style.MozUserSelect = 'none';
+            a.style.pointerEvents = 'none';
+
+            b.style.userSelect = 'none';
+            b.style.webkitUserSelect = 'none';
+            b.style.MozUserSelect = 'none';
+            b.style.pointerEvents = 'none';
+
+            // Set the cursor at multiple levels
+            self.gutter.style.cursor = cursor;
+            self.parent.style.cursor = cursor;
+            document.body.style.cursor = cursor;
+
+            // Cache the initial sizes of the pair.
+            calculateSizes.call(self);
+
+            // Determine the position of the mouse compared to the gutter
+            self.dragOffset = getMousePosition(e) - self.end;
+        }
+
+        // adjust sizes to ensure percentage is within min size and gutter.
+        sizes = trimToMin(sizes);
+
+        // 5. Create pair and element objects. Each pair has an index reference to
+        // elements `a` and `b` of the pair (first and second elements).
+        // Loop through the elements while pairing them off. Every pair gets a
+        // `pair` object and a gutter.
+        //
+        // Basic logic:
+        //
+        // - Starting with the second element `i > 0`, create `pair` objects with
+        //   `a = i - 1` and `b = i`
+        // - Set gutter sizes based on the _pair_ being first/last. The first and last
+        //   pair have gutterSize / 2, since they only have one half gutter, and not two.
+        // - Create gutter elements and add event listeners.
+        // - Set the size of the elements, minus the gutter sizes.
+        //
+        // -----------------------------------------------------------------------
+        // |     i=0     |         i=1         |        i=2       |      i=3     |
+        // |             |                     |                  |              |
+        // |           pair 0                pair 1             pair 2           |
+        // |             |                     |                  |              |
+        // -----------------------------------------------------------------------
+        var pairs = [];
+        elements = ids.map(function (id, i) {
+            // Create the element object.
+            var element = {
+                element: elementOrSelector(id),
+                size: sizes[i],
+                minSize: minSizes[i],
+                i: i,
+            };
+
+            var pair;
+
+            if (i > 0) {
+                // Create the pair object with its metadata.
+                pair = {
+                    a: i - 1,
+                    b: i,
+                    dragging: false,
+                    direction: direction,
+                    parent: parent,
+                };
+
+                pair[aGutterSize] = getGutterSize(
+                    gutterSize,
+                    i - 1 === 0,
+                    false,
+                    gutterAlign
+                );
+                pair[bGutterSize] = getGutterSize(
+                    gutterSize,
+                    false,
+                    i === ids.length - 1,
+                    gutterAlign
+                );
+
+                // if the parent has a reverse flex-direction, switch the pair elements.
+                if (
+                    parentFlexDirection === 'row-reverse' ||
+                    parentFlexDirection === 'column-reverse'
+                ) {
+                    var temp = pair.a;
+                    pair.a = pair.b;
+                    pair.b = temp;
+                }
+            }
+
+            // Determine the size of the current element. IE8 is supported by
+            // staticly assigning sizes without draggable gutters. Assigns a string
+            // to `size`.
+            //
+            // IE9 and above
+            if (!isIE8) {
+                // Create gutter elements for each pair.
+                if (i > 0) {
+                    var gutterElement = gutter(i, direction, element.element);
+                    setGutterSize(gutterElement, gutterSize, i);
+
+                    // Save bound event listener for removal later
+                    pair[gutterStartDragging] = startDragging.bind(pair);
+
+                    // Attach bound event listener
+                    gutterElement[addEventListener](
+                        'mousedown',
+                        pair[gutterStartDragging]
+                    );
+                    gutterElement[addEventListener](
+                        'touchstart',
+                        pair[gutterStartDragging]
+                    );
+
+                    parent.insertBefore(gutterElement, element.element);
+
+                    pair.gutter = gutterElement;
+                }
+            }
+
+            setElementSize(
+                element.element,
+                element.size,
+                getGutterSize(
+                    gutterSize,
+                    i === 0,
+                    i === ids.length - 1,
+                    gutterAlign
+                ),
+                i
+            );
+
+            // After the first iteration, and we have a pair object, append it to the
+            // list of pairs.
+            if (i > 0) {
+                pairs.push(pair);
+            }
+
+            return element
+        });
+
+        function adjustToMin(element) {
+            var isLast = element.i === pairs.length;
+            var pair = isLast ? pairs[element.i - 1] : pairs[element.i];
+
+            calculateSizes.call(pair);
+
+            var size = isLast
+                ? pair.size - element.minSize - pair[bGutterSize]
+                : element.minSize + pair[aGutterSize];
+
+            adjust.call(pair, size);
+        }
+
+        elements.forEach(function (element) {
+            var computedSize = element.element[getBoundingClientRect]()[dimension];
+
+            if (computedSize < element.minSize) {
+                if (expandToMin) {
+                    adjustToMin(element);
+                } else {
+                    // eslint-disable-next-line no-param-reassign
+                    element.minSize = computedSize;
+                }
+            }
+        });
+
+        function setSizes(newSizes) {
+            var trimmed = trimToMin(newSizes);
+            trimmed.forEach(function (newSize, i) {
+                if (i > 0) {
+                    var pair = pairs[i - 1];
+
+                    var a = elements[pair.a];
+                    var b = elements[pair.b];
+
+                    a.size = trimmed[i - 1];
+                    b.size = newSize;
+
+                    setElementSize(a.element, a.size, pair[aGutterSize], a.i);
+                    setElementSize(b.element, b.size, pair[bGutterSize], b.i);
+                }
+            });
+        }
+
+        function destroy(preserveStyles, preserveGutter) {
+            pairs.forEach(function (pair) {
+                if (preserveGutter !== true) {
+                    pair.parent.removeChild(pair.gutter);
+                } else {
+                    pair.gutter[removeEventListener](
+                        'mousedown',
+                        pair[gutterStartDragging]
+                    );
+                    pair.gutter[removeEventListener](
+                        'touchstart',
+                        pair[gutterStartDragging]
+                    );
+                }
+
+                if (preserveStyles !== true) {
+                    var style = elementStyle(
+                        dimension,
+                        pair.a.size,
+                        pair[aGutterSize]
+                    );
+
+                    Object.keys(style).forEach(function (prop) {
+                        elements[pair.a].element.style[prop] = '';
+                        elements[pair.b].element.style[prop] = '';
+                    });
+                }
+            });
+        }
+
+        if (isIE8) {
+            return {
+                setSizes: setSizes,
+                destroy: destroy,
+            }
+        }
+
+        return {
+            setSizes: setSizes,
+            getSizes: getSizes,
+            collapse: function collapse(i) {
+                adjustToMin(elements[i]);
+            },
+            destroy: destroy,
+            parent: parent,
+            pairs: pairs,
+        }
+    };
+
+    return Split;
+
+})));

--- a/assets/style.css
+++ b/assets/style.css
@@ -26,7 +26,7 @@ h4 {
 }
 
 a {
-  color: #1184CE;
+  color: #1184ce;
   text-decoration: none;
 }
 
@@ -51,12 +51,12 @@ a:hover {
 }
 
 section:target h3 {
-  font-weight:700;
+  font-weight: 700;
 }
 
 .documentation td,
 .documentation th {
-    padding: .25rem .25rem;
+  padding: 0.25rem 0.25rem;
 }
 
 h1:hover .anchorjs-link,
@@ -82,13 +82,16 @@ h4:hover .anchorjs-link {
   }
 }
 
-.pre, pre, code, .code {
-  font-family: Source Code Pro,Menlo,Consolas,Liberation Mono,monospace;
+.pre,
+pre,
+code,
+.code {
+  font-family: Source Code Pro, Menlo, Consolas, Liberation Mono, monospace;
   font-size: 14px;
 }
 
 .fill-light {
-  background: #F9F9F9;
+  background: #f9f9f9;
 }
 
 .width2 {
@@ -100,10 +103,10 @@ h4:hover .anchorjs-link {
   display: block;
   width: 100%;
   height: 2rem;
-  padding: .5rem;
+  padding: 0.5rem;
   margin-bottom: 1rem;
   border: 1px solid #ccc;
-  font-size: .875rem;
+  font-size: 0.875rem;
   border-radius: 3px;
   box-sizing: border-box;
 }
@@ -115,15 +118,19 @@ table {
 .prose table th,
 .prose table td {
   text-align: left;
-  padding:8px;
-  border:1px solid #ddd;
+  padding: 8px;
+  border: 1px solid #ddd;
 }
 
-.prose table th:nth-child(1) { border-right: none; }
-.prose table th:nth-child(2) { border-left: none; }
+.prose table th:nth-child(1) {
+  border-right: none;
+}
+.prose table th:nth-child(2) {
+  border-left: none;
+}
 
 .prose table {
-  border:1px solid #ddd;
+  border: 1px solid #ddd;
 }
 
 .prose-big {

--- a/index.html
+++ b/index.html
@@ -1,24 +1,28 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
-  <meta charset='utf-8' />
-  <title>simple-statistics 6.0.0 | Documentation</title>
+  <meta charset='utf-8'>
+  <title>simple-statistics-docs 7.8.7 | Documentation</title>
+  <meta name='description' content='simple statistics documentation website'>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
-  <link href='assets/bass.css' type='text/css' rel='stylesheet' />
-  <link href='assets/style.css' type='text/css' rel='stylesheet' />
-  <link href='assets/github.css' type='text/css' rel='stylesheet' />
-  <link href='assets/split.css' type='text/css' rel='stylesheet' />
+  <link href='assets/bass.css' rel='stylesheet'>
+  <link href='assets/style.css' rel='stylesheet'>
+  <link href='assets/github.css' rel='stylesheet'>
+  <link href='assets/split.css' rel='stylesheet'>
 </head>
 <body class='documentation m0'>
     <div class='flex'>
       <div id='split-left' class='overflow-auto fs0 height-viewport-100'>
         <div class='py1 px2'>
-          <h3 class='mb0 no-anchor'>simple-statistics</h3>
-          <div class='mb1'><code>6.0.0</code></div>
+          <h3 class='mb0 no-anchor'>simple-statistics-docs</h3>
+          <div class='mb1'><code>7.8.7</code></div>
           <input
             placeholder='Filter'
             id='filter-input'
             class='col12 block input'
+            spellcheck='false'
+            autocapitalize='off'
+            autocorrect='off'
             type='text' />
           <div id='toc'>
             <ul class='list-reset h5 py1-ul'>
@@ -783,9 +787,29 @@
               
                 
                 <li><a
+                  href='#approxequal'
+                  class="">
+                  approxEqual
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
                   href='#bisect'
                   class="">
                   bisect
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#coefficientofvariation'
+                  class="">
+                  coefficientOfVariation
                   
                 </a>
                 
@@ -833,6 +857,26 @@
               
                 
                 <li><a
+                  href='#cumulativestdlogisticprobability'
+                  class="">
+                  cumulativeStdLogisticProbability
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#euclideandistance'
+                  class="">
+                  euclideanDistance
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
                   href='#extentsorted'
                   class="">
                   extentSorted
@@ -846,6 +890,76 @@
                   href='#extent'
                   class="">
                   extent
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#gammaln'
+                  class="">
+                  gammaln
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#jenks'
+                  class="">
+                  jenks
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#kmeansreturn'
+                  class="">
+                  kMeansReturn
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#kmeanscluster'
+                  class="">
+                  kMeansCluster
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#logaverage'
+                  class="">
+                  logAverage
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#logit'
+                  class="">
+                  logit
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#meansimple'
+                  class="">
+                  meanSimple
                   
                 </a>
                 
@@ -903,9 +1017,49 @@
               
                 
                 <li><a
+                  href='#relativeerror'
+                  class="">
+                  relativeError
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
                   href='#samplekurtosis'
                   class="">
                   sampleKurtosis
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#samplerankcorrelation'
+                  class="">
+                  sampleRankCorrelation
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#silhouettemetric'
+                  class="">
+                  silhouetteMetric
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#silhouette'
+                  class="">
+                  silhouette
                   
                 </a>
                 
@@ -921,10 +1075,20 @@
                 
                 </li>
               
+                
+                <li><a
+                  href='#wilcoxonranksum'
+                  class="">
+                  wilcoxonRankSum
+                  
+                </a>
+                
+                </li>
+              
             </ul>
           </div>
           <div class='mt1 h6 quiet'>
-            <a href='http://documentation.js.org/reading-documentation.html'>Need help reading this?</a>
+            <a href='https://documentation.js.org/reading-documentation.html'>Need help reading this?</a>
           </div>
         </div>
       </div>
@@ -939,14 +1103,12 @@
 
   
     
-
   
-</section>
-</div>
+</section></div>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -959,10 +1121,10 @@
   </div>
   
 
-  <p>The min is the lowest number in the array. This runs on <code>O(n)</code>, linear time in respect to the array</p>
+  <p>The min is the lowest number in the array.
+This runs in <code>O(n)</code>, linear time, with respect to the length of the array.</p>
 
-
-  <div class='pre p1 fill-light mt0'>min(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>min(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -1002,10 +1164,12 @@
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
-        <li><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>: if the the length of x is less than one
+        <li><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>: if the length of x is less than one
 </li>
       
     </ul>
@@ -1015,8 +1179,10 @@
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>min([<span class="hljs-number">1</span>, <span class="hljs-number">5</span>, <span class="hljs-number">-10</span>, <span class="hljs-number">100</span>, <span class="hljs-number">2</span>]); <span class="hljs-comment">// =&gt; -10</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">min</span>([<span class="hljs-number">1</span>, <span class="hljs-number">5</span>, -<span class="hljs-number">10</span>, <span class="hljs-number">100</span>, <span class="hljs-number">2</span>]); <span class="hljs-comment">// =&gt; -10</span></pre>
     
+  
+
   
 
   
@@ -1029,7 +1195,7 @@
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -1043,10 +1209,9 @@
   
 
   <p>This computes the maximum number in an array.</p>
-<p>This runs on <code>O(n)</code>, linear time in respect to the array</p>
+<p>This runs in <code>O(n)</code>, linear time, with respect to the length of the array.</p>
 
-
-  <div class='pre p1 fill-light mt0'>max(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>max(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -1086,10 +1251,12 @@
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
-        <li><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>: if the the length of x is less than one
+        <li><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>: if the length of x is less than one
 </li>
       
     </ul>
@@ -1099,9 +1266,11 @@
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>max([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>]);
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">max</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>]);
 <span class="hljs-comment">// =&gt; 4</span></pre>
     
+  
+
   
 
   
@@ -1114,7 +1283,7 @@
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -1136,10 +1305,9 @@ successive additions, each one with its own floating-point roundoff. These
 losses in precision add up as the number of numbers increases. This alternative
 algorithm is more accurate than the simple way of calculating sums by simple
 addition.</p>
-<p>This runs on <code>O(n)</code>, linear time in respect to the array.</p>
+<p>This runs in <code>O(n)</code>, linear time, with respect to the length of the array.</p>
 
-
-  <div class='pre p1 fill-light mt0'>sum(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>sum(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -1181,11 +1349,15 @@ addition.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>sum([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]); <span class="hljs-comment">// =&gt; 6</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">sum</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]); <span class="hljs-comment">// =&gt; 6</span></pre>
     
+  
+
   
 
   
@@ -1198,7 +1370,7 @@ addition.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -1213,10 +1385,9 @@ addition.</p>
 
   <p>The simple <a href="https://en.wikipedia.org/wiki/Summation">sum</a> of an array
 is the result of adding all numbers together, starting from zero.</p>
-<p>This runs on <code>O(n)</code>, linear time in respect to the array</p>
+<p>This runs in <code>O(n)</code>, linear time, with respect to the length of the array.</p>
 
-
-  <div class='pre p1 fill-light mt0'>sumSimple(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>sumSimple(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -1258,11 +1429,15 @@ is the result of adding all numbers together, starting from zero.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>sumSimple([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]); <span class="hljs-comment">// =&gt; 6</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">sumSimple</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]); <span class="hljs-comment">// =&gt; 6</span></pre>
     
+  
+
   
 
   
@@ -1275,7 +1450,7 @@ is the result of adding all numbers together, starting from zero.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -1301,8 +1476,7 @@ with decimal values.
 When p is an array, the result of the function is also an array containing the appropriate
 quantiles in input order</p>
 
-
-  <div class='pre p1 fill-light mt0'>quantile(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, p: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>quantile(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, p: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -1353,11 +1527,15 @@ quantiles in input order</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>quantile([<span class="hljs-number">3</span>, <span class="hljs-number">6</span>, <span class="hljs-number">7</span>, <span class="hljs-number">8</span>, <span class="hljs-number">8</span>, <span class="hljs-number">9</span>, <span class="hljs-number">10</span>, <span class="hljs-number">13</span>, <span class="hljs-number">15</span>, <span class="hljs-number">16</span>, <span class="hljs-number">20</span>], <span class="hljs-number">0.5</span>); <span class="hljs-comment">// =&gt; 9</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">quantile</span>([<span class="hljs-number">3</span>, <span class="hljs-number">6</span>, <span class="hljs-number">7</span>, <span class="hljs-number">8</span>, <span class="hljs-number">8</span>, <span class="hljs-number">9</span>, <span class="hljs-number">10</span>, <span class="hljs-number">13</span>, <span class="hljs-number">15</span>, <span class="hljs-number">16</span>, <span class="hljs-number">20</span>], <span class="hljs-number">0.5</span>); <span class="hljs-comment">// =&gt; 9</span></pre>
     
+  
+
   
 
   
@@ -1370,7 +1548,7 @@ quantiles in input order</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -1385,10 +1563,9 @@ quantiles in input order</p>
 
   <p>The <a href="https://en.wikipedia.org/wiki/Product_(mathematics)">product</a> of an array
 is the result of multiplying all numbers together, starting using one as the multiplicative identity.</p>
-<p>This runs on <code>O(n)</code>, linear time in respect to the array</p>
+<p>This runs in <code>O(n)</code>, linear time, with respect to the length of the array.</p>
 
-
-  <div class='pre p1 fill-light mt0'>product(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>product(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -1430,11 +1607,15 @@ is the result of multiplying all numbers together, starting using one as the mul
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>product([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>]); <span class="hljs-comment">// =&gt; 24</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">product</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>]); <span class="hljs-comment">// =&gt; 24</span></pre>
     
+  
+
   
 
   
@@ -1459,12 +1640,11 @@ is sorted. This assumptions lets them run a lot faster, usually
 in O(1).</p>
 
   
-</section>
-</div>
+</section></div>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -1481,8 +1661,7 @@ in O(1).</p>
 the first element in the array is always the smallest, so this calculation
 can be done in one step, or constant time.</p>
 
-
-  <div class='pre p1 fill-light mt0'>minSorted(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>minSorted(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -1524,11 +1703,15 @@ can be done in one step, or constant time.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>minSorted([<span class="hljs-number">-100</span>, <span class="hljs-number">-10</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">5</span>]); <span class="hljs-comment">// =&gt; -100</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">minSorted</span>([-<span class="hljs-number">100</span>, -<span class="hljs-number">10</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">5</span>]); <span class="hljs-comment">// =&gt; -100</span></pre>
     
+  
+
   
 
   
@@ -1541,7 +1724,7 @@ can be done in one step, or constant time.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -1558,8 +1741,7 @@ can be done in one step, or constant time.</p>
 the last element in the array is always the largest, so this calculation
 can be done in one step, or constant time.</p>
 
-
-  <div class='pre p1 fill-light mt0'>maxSorted(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>maxSorted(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -1601,11 +1783,15 @@ can be done in one step, or constant time.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>maxSorted([<span class="hljs-number">-100</span>, <span class="hljs-number">-10</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">5</span>]); <span class="hljs-comment">// =&gt; 5</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">maxSorted</span>([-<span class="hljs-number">100</span>, -<span class="hljs-number">10</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">5</span>]); <span class="hljs-comment">// =&gt; 5</span></pre>
     
+  
+
   
 
   
@@ -1618,7 +1804,7 @@ can be done in one step, or constant time.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -1635,8 +1821,7 @@ can be done in one step, or constant time.</p>
 that the order is sorted, you don't need to re-sort it, and the computations
 are faster.</p>
 
-
-  <div class='pre p1 fill-light mt0'>quantileSorted(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, p: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>quantileSorted(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, p: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -1685,6 +1870,8 @@ are faster.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
@@ -1701,8 +1888,10 @@ are faster.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>quantileSorted([<span class="hljs-number">3</span>, <span class="hljs-number">6</span>, <span class="hljs-number">7</span>, <span class="hljs-number">8</span>, <span class="hljs-number">8</span>, <span class="hljs-number">9</span>, <span class="hljs-number">10</span>, <span class="hljs-number">13</span>, <span class="hljs-number">15</span>, <span class="hljs-number">16</span>, <span class="hljs-number">20</span>], <span class="hljs-number">0.5</span>); <span class="hljs-comment">// =&gt; 9</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">quantileSorted</span>([<span class="hljs-number">3</span>, <span class="hljs-number">6</span>, <span class="hljs-number">7</span>, <span class="hljs-number">8</span>, <span class="hljs-number">8</span>, <span class="hljs-number">9</span>, <span class="hljs-number">10</span>, <span class="hljs-number">13</span>, <span class="hljs-number">15</span>, <span class="hljs-number">16</span>, <span class="hljs-number">20</span>], <span class="hljs-number">0.5</span>); <span class="hljs-comment">// =&gt; 9</span></pre>
     
+  
+
   
 
   
@@ -1726,12 +1915,11 @@ are faster.</p>
 a distribution.</p>
 
   
-</section>
-</div>
+</section></div>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -1748,10 +1936,9 @@ a distribution.</p>
 is the sum of all values over the number of values.
 This is a <a href="https://en.wikipedia.org/wiki/Central_tendency">measure of central tendency</a>:
 a method of finding a typical or central value of a set of numbers.</p>
-<p>This runs on <code>O(n)</code>, linear time in respect to the array</p>
+<p>This runs in <code>O(n)</code>, linear time, with respect to the length of the array.</p>
 
-
-  <div class='pre p1 fill-light mt0'>mean(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>mean(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -1791,10 +1978,12 @@ a method of finding a typical or central value of a set of numbers.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
-        <li><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>: if the the length of x is less than one
+        <li><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>: if the length of x is less than one
 </li>
       
     </ul>
@@ -1804,8 +1993,10 @@ a method of finding a typical or central value of a set of numbers.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>mean([<span class="hljs-number">0</span>, <span class="hljs-number">10</span>]); <span class="hljs-comment">// =&gt; 5</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">mean</span>([<span class="hljs-number">0</span>, <span class="hljs-number">10</span>]); <span class="hljs-comment">// =&gt; 5</span></pre>
     
+  
+
   
 
   
@@ -1818,7 +2009,7 @@ a method of finding a typical or central value of a set of numbers.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -1837,8 +2028,7 @@ this function to compute the new mean by providing the current mean,
 the number of elements in the list that produced it and the new
 value to add.</p>
 
-
-  <div class='pre p1 fill-light mt0'>addToMean(mean: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, n: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, newValue: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>addToMean(mean: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, n: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, newValue: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -1898,11 +2088,15 @@ value to add.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>addToMean(<span class="hljs-number">14</span>, <span class="hljs-number">5</span>, <span class="hljs-number">53</span>); <span class="hljs-comment">// =&gt; 20.5</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">addToMean</span>(<span class="hljs-number">14</span>, <span class="hljs-number">5</span>, <span class="hljs-number">53</span>); <span class="hljs-comment">// =&gt; 20.5</span></pre>
     
+  
+
   
 
   
@@ -1915,7 +2109,7 @@ value to add.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -1928,16 +2122,16 @@ value to add.</p>
   </div>
   
 
-  <p>The <a href="http://bit.ly/W5K4Yt">mode</a> is the number that appears in a list the highest number of times.
+  <p>The <a href="https://en.wikipedia.org/wiki/Mode_%28statistics%29">mode</a> is the number
+that appears in a list the highest number of times.
 There can be multiple modes in a list: in the event of a tie, this
 algorithm will return the most recently seen mode.</p>
 <p>This is a <a href="https://en.wikipedia.org/wiki/Central_tendency">measure of central tendency</a>:
 a method of finding a typical or central value of a set of numbers.</p>
-<p>This runs on <code>O(nlog(n))</code> because it needs to sort the array internally
+<p>This runs in <code>O(n log(n))</code> because it needs to sort the array internally
 before running an <code>O(n)</code> search to find the mode.</p>
 
-
-  <div class='pre p1 fill-light mt0'>mode(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>mode(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -1979,11 +2173,15 @@ before running an <code>O(n)</code> search to find the mode.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>mode([<span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// =&gt; 0</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">mode</span>([<span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// =&gt; 0</span></pre>
     
+  
+
   
 
   
@@ -1996,7 +2194,7 @@ before running an <code>O(n)</code> search to find the mode.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -2009,15 +2207,15 @@ before running an <code>O(n)</code> search to find the mode.</p>
   </div>
   
 
-  <p>The <a href="http://bit.ly/W5K4Yt">mode</a> is the number that appears in a list the highest number of times.
+  <p>The <a href="https://en.wikipedia.org/wiki/Mode_%28statistics%29">mode</a> is the number
+that appears in a list the highest number of times.
 There can be multiple modes in a list: in the event of a tie, this
 algorithm will return the most recently seen mode.</p>
 <p>This is a <a href="https://en.wikipedia.org/wiki/Central_tendency">measure of central tendency</a>:
 a method of finding a typical or central value of a set of numbers.</p>
 <p>This runs in <code>O(n)</code> because the input is sorted.</p>
 
-
-  <div class='pre p1 fill-light mt0'>modeSorted(sorted: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>modeSorted(sorted: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -2057,6 +2255,8 @@ a method of finding a typical or central value of a set of numbers.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
@@ -2070,8 +2270,10 @@ a method of finding a typical or central value of a set of numbers.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>modeSorted([<span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// =&gt; 0</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">modeSorted</span>([<span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// =&gt; 0</span></pre>
     
+  
+
   
 
   
@@ -2084,7 +2286,7 @@ a method of finding a typical or central value of a set of numbers.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -2097,7 +2299,8 @@ a method of finding a typical or central value of a set of numbers.</p>
   </div>
   
 
-  <p>The <a href="http://bit.ly/W5K4Yt">mode</a> is the number that appears in a list the highest number of times.
+  <p>The <a href="https://en.wikipedia.org/wiki/Mode_%28statistics%29">mode</a> is the number
+that appears in a list the highest number of times.
 There can be multiple modes in a list: in the event of a tie, this
 algorithm will return the most recently seen mode.</p>
 <p>modeFast uses a Map object to keep track of the mode, instead of the approach
@@ -2109,8 +2312,7 @@ and will throw an error if Map is not available.</p>
 <p>This is a <a href="https://en.wikipedia.org/wiki/Central_tendency">measure of central tendency</a>:
 a method of finding a typical or central value of a set of numbers.</p>
 
-
-  <div class='pre p1 fill-light mt0'>modeFast(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;any>): any?</div>
+    <div class='pre p1 fill-light mt0'>modeFast(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;any>): any?</div>
   
   
 
@@ -2150,6 +2352,8 @@ a method of finding a typical or central value of a set of numbers.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
@@ -2166,8 +2370,10 @@ a method of finding a typical or central value of a set of numbers.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>modeFast([<span class="hljs-string">'rabbits'</span>, <span class="hljs-string">'rabbits'</span>, <span class="hljs-string">'squirrels'</span>]); <span class="hljs-comment">// =&gt; 'rabbits'</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">modeFast</span>([<span class="hljs-string">&#x27;rabbits&#x27;</span>, <span class="hljs-string">&#x27;rabbits&#x27;</span>, <span class="hljs-string">&#x27;squirrels&#x27;</span>]); <span class="hljs-comment">// =&gt; &#x27;rabbits&#x27;</span></pre>
     
+  
+
   
 
   
@@ -2180,7 +2386,7 @@ a method of finding a typical or central value of a set of numbers.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -2202,8 +2408,7 @@ a method of finding a typical or central value of a set of numbers.</p>
 can be the average of two elements if the list has an even length
 and the two central values are different.</p>
 
-
-  <div class='pre p1 fill-light mt0'>median(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>median(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -2245,11 +2450,15 @@ and the two central values are different.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>median([<span class="hljs-number">10</span>, <span class="hljs-number">2</span>, <span class="hljs-number">5</span>, <span class="hljs-number">100</span>, <span class="hljs-number">2</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// =&gt; 3.5</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">median</span>([<span class="hljs-number">10</span>, <span class="hljs-number">2</span>, <span class="hljs-number">5</span>, <span class="hljs-number">100</span>, <span class="hljs-number">2</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// =&gt; 3.5</span></pre>
     
+  
+
   
 
   
@@ -2262,7 +2471,7 @@ and the two central values are different.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -2284,8 +2493,7 @@ a method of finding a typical or central value of a set of numbers.</p>
 can be the average of two elements if the list has an even length
 and the two central values are different.</p>
 
-
-  <div class='pre p1 fill-light mt0'>medianSorted(sorted: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>medianSorted(sorted: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -2327,11 +2535,15 @@ and the two central values are different.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>medianSorted([<span class="hljs-number">10</span>, <span class="hljs-number">2</span>, <span class="hljs-number">5</span>, <span class="hljs-number">100</span>, <span class="hljs-number">2</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// =&gt; 52.5</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">medianSorted</span>([<span class="hljs-number">10</span>, <span class="hljs-number">2</span>, <span class="hljs-number">5</span>, <span class="hljs-number">100</span>, <span class="hljs-number">2</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// =&gt; 52.5</span></pre>
     
+  
+
   
 
   
@@ -2344,7 +2556,7 @@ and the two central values are different.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -2363,10 +2575,9 @@ This mean is calculated by taking the reciprocal of the arithmetic mean
 of the reciprocals of the input numbers.</p>
 <p>This is a <a href="https://en.wikipedia.org/wiki/Central_tendency">measure of central tendency</a>:
 a method of finding a typical or central value of a set of numbers.</p>
-<p>This runs on <code>O(n)</code>, linear time in respect to the array.</p>
+<p>This runs in <code>O(n)</code>, linear time, with respect to the length of the array.</p>
 
-
-  <div class='pre p1 fill-light mt0'>harmonicMean(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>harmonicMean(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -2406,6 +2617,8 @@ a method of finding a typical or central value of a set of numbers.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
@@ -2422,8 +2635,10 @@ a method of finding a typical or central value of a set of numbers.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>harmonicMean([<span class="hljs-number">2</span>, <span class="hljs-number">3</span>]).toFixed(<span class="hljs-number">2</span>) <span class="hljs-comment">// =&gt; '2.40'</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">harmonicMean</span>([<span class="hljs-number">2</span>, <span class="hljs-number">3</span>]).<span class="hljs-title function_">toFixed</span>(<span class="hljs-number">2</span>) <span class="hljs-comment">// =&gt; &#x27;2.40&#x27;</span></pre>
     
+  
+
   
 
   
@@ -2436,7 +2651,7 @@ a method of finding a typical or central value of a set of numbers.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -2459,10 +2674,9 @@ growth rates for multiple years, like <em>80%, 16.66% and 42.85%</em>, a simple
 mean will incorrectly estimate an average growth rate, whereas a geometric
 mean will correctly estimate a growth rate that, over those years,
 will yield the same end value.</p>
-<p>This runs on <code>O(n)</code>, linear time in respect to the array</p>
+<p>This runs in <code>O(n)</code>, linear time, with respect to the length of the array.</p>
 
-
-  <div class='pre p1 fill-light mt0'>geometricMean(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>geometricMean(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -2502,6 +2716,8 @@ will yield the same end value.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
@@ -2519,18 +2735,20 @@ will yield the same end value.</p>
     
       
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> growthRates = [<span class="hljs-number">1.80</span>, <span class="hljs-number">1.166666</span>, <span class="hljs-number">1.428571</span>];
-<span class="hljs-keyword">var</span> averageGrowth = ss.geometricMean(growthRates);
+<span class="hljs-keyword">var</span> averageGrowth = ss.<span class="hljs-title function_">geometricMean</span>(growthRates);
 <span class="hljs-keyword">var</span> averageGrowthRates = [averageGrowth, averageGrowth, averageGrowth];
 <span class="hljs-keyword">var</span> startingValue = <span class="hljs-number">10</span>;
 <span class="hljs-keyword">var</span> startingValueMean = <span class="hljs-number">10</span>;
-growthRates.forEach(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">rate</span>) </span>{
+growthRates.<span class="hljs-title function_">forEach</span>(<span class="hljs-keyword">function</span>(<span class="hljs-params">rate</span>) {
   startingValue *= rate;
 });
-averageGrowthRates.forEach(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">rate</span>) </span>{
+averageGrowthRates.<span class="hljs-title function_">forEach</span>(<span class="hljs-keyword">function</span>(<span class="hljs-params">rate</span>) {
   startingValueMean *= rate;
 });
 startingValueMean === startingValue;</pre>
     
+  
+
   
 
   
@@ -2543,7 +2761,7 @@ startingValueMean === startingValue;</pre>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -2561,10 +2779,9 @@ a mean function used as a measure of the magnitude of a set
 of numbers, regardless of their sign.
 This is the square root of the mean of the squares of the
 input numbers.
-This runs on <code>O(n)</code>, linear time in respect to the array</p>
+This runs in <code>O(n)</code>, linear time, with respect to the length of the array.</p>
 
-
-  <div class='pre p1 fill-light mt0'>rootMeanSquare(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>rootMeanSquare(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -2604,6 +2821,8 @@ This runs on <code>O(n)</code>, linear time in respect to the array</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
@@ -2617,8 +2836,10 @@ This runs on <code>O(n)</code>, linear time in respect to the array</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>rootMeanSquare([<span class="hljs-number">-1</span>, <span class="hljs-number">1</span>, <span class="hljs-number">-1</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// =&gt; 1</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">rootMeanSquare</span>([-<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, -<span class="hljs-number">1</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// =&gt; 1</span></pre>
     
+  
+
   
 
   
@@ -2631,7 +2852,7 @@ This runs on <code>O(n)</code>, linear time in respect to the array</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -2652,8 +2873,7 @@ The skewness value can be positive or negative, or even undefined.</p>
 moment coefficient, which is the version found in Excel and several
 statistical packages including Minitab, SAS and SPSS.</p>
 
-
-  <div class='pre p1 fill-light mt0'>sampleSkewness(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>sampleSkewness(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -2693,6 +2913,8 @@ statistical packages including Minitab, SAS and SPSS.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
@@ -2706,8 +2928,10 @@ statistical packages including Minitab, SAS and SPSS.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>sampleSkewness([<span class="hljs-number">2</span>, <span class="hljs-number">4</span>, <span class="hljs-number">6</span>, <span class="hljs-number">3</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// =&gt; 0.590128656384365</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">sampleSkewness</span>([<span class="hljs-number">2</span>, <span class="hljs-number">4</span>, <span class="hljs-number">6</span>, <span class="hljs-number">3</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// =&gt; 0.590128656384365</span></pre>
     
+  
+
   
 
   
@@ -2730,12 +2954,11 @@ statistical packages including Minitab, SAS and SPSS.</p>
     <p>These are different ways of determining how spread out a distribution is.</p>
 
   
-</section>
-</div>
+</section></div>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -2753,8 +2976,7 @@ is the sum of squared deviations from the mean.</p>
 <p>This is an implementation of variance, not sample variance:
 see the <code>sampleVariance</code> method if you want a sample measure.</p>
 
-
-  <div class='pre p1 fill-light mt0'>variance(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>variance(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -2795,6 +3017,8 @@ zero indicates that all values are identical.
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
@@ -2808,8 +3032,10 @@ zero indicates that all values are identical.
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>variance([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">6</span>]); <span class="hljs-comment">// =&gt; 2.9166666666666665</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">variance</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">6</span>]); <span class="hljs-comment">// =&gt; 2.9166666666666665</span></pre>
     
+  
+
   
 
   
@@ -2822,7 +3048,7 @@ zero indicates that all values are identical.
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -2846,8 +3072,7 @@ a value from a set that you don't know if full.</p>
 <li><a href="http://mathworld.wolfram.com/SampleVariance.html">Wolfram MathWorld on Sample Variance</a></li>
 </ul>
 
-
-  <div class='pre p1 fill-light mt0'>sampleVariance(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>sampleVariance(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -2887,6 +3112,8 @@ a value from a set that you don't know if full.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
@@ -2900,8 +3127,10 @@ a value from a set that you don't know if full.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>sampleVariance([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>]); <span class="hljs-comment">// =&gt; 2.5</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">sampleVariance</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>]); <span class="hljs-comment">// =&gt; 2.5</span></pre>
     
+  
+
   
 
   
@@ -2914,7 +3143,7 @@ a value from a set that you don't know if full.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -2935,8 +3164,7 @@ of variation or dispersion in a set of values.</p>
 samples of a population, <a href="#samplestandarddeviation">sampleStandardDeviation</a> is
 more appropriate.</p>
 
-
-  <div class='pre p1 fill-light mt0'>standardDeviation(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>standardDeviation(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -2978,12 +3206,16 @@ more appropriate.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>variance([<span class="hljs-number">2</span>, <span class="hljs-number">4</span>, <span class="hljs-number">4</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">5</span>, <span class="hljs-number">7</span>, <span class="hljs-number">9</span>]); <span class="hljs-comment">// =&gt; 4</span>
-standardDeviation([<span class="hljs-number">2</span>, <span class="hljs-number">4</span>, <span class="hljs-number">4</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">5</span>, <span class="hljs-number">7</span>, <span class="hljs-number">9</span>]); <span class="hljs-comment">// =&gt; 2</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">variance</span>([<span class="hljs-number">2</span>, <span class="hljs-number">4</span>, <span class="hljs-number">4</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">5</span>, <span class="hljs-number">7</span>, <span class="hljs-number">9</span>]); <span class="hljs-comment">// =&gt; 4</span>
+<span class="hljs-title function_">standardDeviation</span>([<span class="hljs-number">2</span>, <span class="hljs-number">4</span>, <span class="hljs-number">4</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">5</span>, <span class="hljs-number">7</span>, <span class="hljs-number">9</span>]); <span class="hljs-comment">// =&gt; 2</span></pre>
     
+  
+
   
 
   
@@ -2996,7 +3228,7 @@ standardDeviation([<span class="hljs-number">2</span>, <span class="hljs-number"
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -3012,8 +3244,7 @@ standardDeviation([<span class="hljs-number">2</span>, <span class="hljs-number"
   <p>The <a href="http://en.wikipedia.org/wiki/Standard_deviation#Sample_standard_deviation">sample standard deviation</a>
 is the square root of the sample variance.</p>
 
-
-  <div class='pre p1 fill-light mt0'>sampleStandardDeviation(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>sampleStandardDeviation(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -3055,12 +3286,16 @@ is the square root of the sample variance.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>sampleStandardDeviation([<span class="hljs-number">2</span>, <span class="hljs-number">4</span>, <span class="hljs-number">4</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">5</span>, <span class="hljs-number">7</span>, <span class="hljs-number">9</span>]).toFixed(<span class="hljs-number">2</span>);
-<span class="hljs-comment">// =&gt; '2.14'</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">sampleStandardDeviation</span>([<span class="hljs-number">2</span>, <span class="hljs-number">4</span>, <span class="hljs-number">4</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">5</span>, <span class="hljs-number">7</span>, <span class="hljs-number">9</span>]).<span class="hljs-title function_">toFixed</span>(<span class="hljs-number">2</span>);
+<span class="hljs-comment">// =&gt; &#x27;2.14&#x27;</span></pre>
     
+  
+
   
 
   
@@ -3073,7 +3308,7 @@ is the square root of the sample variance.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -3090,8 +3325,7 @@ is the square root of the sample variance.</p>
 a robust measure of statistical
 dispersion. It is more resilient to outliers than the standard deviation.</p>
 
-
-  <div class='pre p1 fill-light mt0'>medianAbsoluteDeviation(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>medianAbsoluteDeviation(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -3133,11 +3367,15 @@ dispersion. It is more resilient to outliers than the standard deviation.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>medianAbsoluteDeviation([<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">2</span>, <span class="hljs-number">4</span>, <span class="hljs-number">6</span>, <span class="hljs-number">9</span>]); <span class="hljs-comment">// =&gt; 1</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">medianAbsoluteDeviation</span>([<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">2</span>, <span class="hljs-number">4</span>, <span class="hljs-number">6</span>, <span class="hljs-number">9</span>]); <span class="hljs-comment">// =&gt; 1</span></pre>
     
+  
+
   
 
   
@@ -3150,7 +3388,7 @@ dispersion. It is more resilient to outliers than the standard deviation.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -3168,8 +3406,7 @@ a measure of statistical dispersion, or how scattered, spread, or
 concentrated a distribution is. It's computed as the difference between
 the third quartile and first quartile.</p>
 
-
-  <div class='pre p1 fill-light mt0'>interquartileRange(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>interquartileRange(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -3212,11 +3449,15 @@ the third quartile and first quartile.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>interquartileRange([<span class="hljs-number">0</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]); <span class="hljs-comment">// =&gt; 2</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">interquartileRange</span>([<span class="hljs-number">0</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]); <span class="hljs-comment">// =&gt; 2</span></pre>
     
+  
+
   
 
   
@@ -3229,7 +3470,7 @@ the third quartile and first quartile.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -3246,8 +3487,7 @@ the third quartile and first quartile.</p>
 When n=2 it's the sum of squared deviations.
 When n=3 it's the sum of cubed deviations.</p>
 
-
-  <div class='pre p1 fill-light mt0'>sumNthPowerDeviations(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, n: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>sumNthPowerDeviations(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, n: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -3297,14 +3537,18 @@ When n=3 it's the sum of cubed deviations.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> input = [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>];
 <span class="hljs-comment">// since the variance of a set is the mean squared</span>
 <span class="hljs-comment">// deviations, we can calculate that with sumNthPowerDeviations:</span>
-sumNthPowerDeviations(input, <span class="hljs-number">2</span>) / input.length;</pre>
+<span class="hljs-title function_">sumNthPowerDeviations</span>(input, <span class="hljs-number">2</span>) / input.<span class="hljs-property">length</span>;</pre>
     
+  
+
   
 
   
@@ -3317,7 +3561,7 @@ sumNthPowerDeviations(input, <span class="hljs-number">2</span>) / input.length;
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -3343,8 +3587,7 @@ if one only has a sample set, then the analogous computation with
 sample mean and sample standard deviation yields the
 Student's t-statistic.</p>
 
-
-  <div class='pre p1 fill-light mt0'>zScore(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, mean: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, standardDeviation: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>zScore(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, mean: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, standardDeviation: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -3401,11 +3644,15 @@ Student's t-statistic.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>zScore(<span class="hljs-number">78</span>, <span class="hljs-number">80</span>, <span class="hljs-number">5</span>); <span class="hljs-comment">// =&gt; -0.4</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">zScore</span>(<span class="hljs-number">78</span>, <span class="hljs-number">80</span>, <span class="hljs-number">5</span>); <span class="hljs-comment">// =&gt; -0.4</span></pre>
     
+  
+
   
 
   
@@ -3426,14 +3673,12 @@ Student's t-statistic.</p>
 
   
     
-
   
-</section>
-</div>
+</section></div>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -3449,8 +3694,7 @@ Student's t-statistic.</p>
   <p>The <a href="http://en.wikipedia.org/wiki/Correlation_and_dependence">correlation</a> is
 a measure of how correlated two datasets are, between -1 and 1</p>
 
-
-  <div class='pre p1 fill-light mt0'>sampleCorrelation(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, y: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>sampleCorrelation(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, y: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -3501,12 +3745,16 @@ a measure of how correlated two datasets are, between -1 and 1</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>sampleCorrelation([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">6</span>], [<span class="hljs-number">2</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">60</span>]).toFixed(<span class="hljs-number">2</span>);
-<span class="hljs-comment">// =&gt; '0.69'</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">sampleCorrelation</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">6</span>], [<span class="hljs-number">2</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">60</span>]).<span class="hljs-title function_">toFixed</span>(<span class="hljs-number">2</span>);
+<span class="hljs-comment">// =&gt; &#x27;0.69&#x27;</span></pre>
     
+  
+
   
 
   
@@ -3519,7 +3767,7 @@ a measure of how correlated two datasets are, between -1 and 1</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -3532,12 +3780,11 @@ a measure of how correlated two datasets are, between -1 and 1</p>
   </div>
   
 
-  <p><a href="https://en.wikipedia.org/wiki/Sample_mean_and_sampleCovariance">Sample covariance</a> of two datasets:
+  <p><a href="https://en.wikipedia.org/wiki/Sample_mean_and_covariance">Sample covariance</a> of two datasets:
 how much do the two datasets move together?
 x and y are two datasets, represented as arrays of numbers.</p>
 
-
-  <div class='pre p1 fill-light mt0'>sampleCovariance(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, y: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>sampleCovariance(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, y: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -3586,6 +3833,8 @@ x and y are two datasets, represented as arrays of numbers.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
@@ -3602,8 +3851,10 @@ x and y are two datasets, represented as arrays of numbers.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>sampleCovariance([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">6</span>], [<span class="hljs-number">6</span>, <span class="hljs-number">5</span>, <span class="hljs-number">4</span>, <span class="hljs-number">3</span>, <span class="hljs-number">2</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// =&gt; -3.5</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">sampleCovariance</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">6</span>], [<span class="hljs-number">6</span>, <span class="hljs-number">5</span>, <span class="hljs-number">4</span>, <span class="hljs-number">3</span>, <span class="hljs-number">2</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// =&gt; -3.5</span></pre>
     
+  
+
   
 
   
@@ -3616,7 +3867,7 @@ x and y are two datasets, represented as arrays of numbers.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -3634,8 +3885,7 @@ value of data compared with a function <code>f</code>
 is the sum of the squared differences between the prediction
 and the actual value.</p>
 
-
-  <div class='pre p1 fill-light mt0'>rSquared(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>>, func: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>rSquared(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>>, func: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -3688,13 +3938,17 @@ and the actual value.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> samples = [[<span class="hljs-number">0</span>, <span class="hljs-number">0</span>], [<span class="hljs-number">1</span>, <span class="hljs-number">1</span>]];
-<span class="hljs-keyword">var</span> regressionLine = linearRegressionLine(linearRegression(samples));
-rSquared(samples, regressionLine); <span class="hljs-comment">// = 1 this line is a perfect fit</span></pre>
+<span class="hljs-keyword">var</span> regressionLine = <span class="hljs-title function_">linearRegressionLine</span>(<span class="hljs-title function_">linearRegression</span>(samples));
+<span class="hljs-title function_">rSquared</span>(samples, regressionLine); <span class="hljs-comment">// = 1 this line is a perfect fit</span></pre>
     
+  
+
   
 
   
@@ -3715,14 +3969,12 @@ rSquared(samples, regressionLine); <span class="hljs-comment">// = 1 this line i
 
   
     
-
   
-</section>
-</div>
+</section></div>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -3740,8 +3992,7 @@ is a simple way to find a fitted line
 between a set of coordinates. This algorithm finds the slope and y-intercept of a regression line
 using the least sum of squares.</p>
 
-
-  <div class='pre p1 fill-light mt0'>linearRegression(data: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
+    <div class='pre p1 fill-light mt0'>linearRegression(data: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -3785,11 +4036,15 @@ like
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>linearRegression([[<span class="hljs-number">0</span>, <span class="hljs-number">0</span>], [<span class="hljs-number">1</span>, <span class="hljs-number">1</span>]]); <span class="hljs-comment">// =&gt; { m: 1, b: 0 }</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">linearRegression</span>([[<span class="hljs-number">0</span>, <span class="hljs-number">0</span>], [<span class="hljs-number">1</span>, <span class="hljs-number">1</span>]]); <span class="hljs-comment">// =&gt; { m: 1, b: 0 }</span></pre>
     
+  
+
   
 
   
@@ -3802,7 +4057,7 @@ like
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -3820,8 +4075,7 @@ with <code>m</code> and <code>b</code> values indicating slope and intercept,
 respectively, generate a line function that translates
 x values into y values.</p>
 
-
-  <div class='pre p1 fill-light mt0'>linearRegressionLine(mb: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a></div>
+    <div class='pre p1 fill-light mt0'>linearRegressionLine(mb: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a></div>
   
   
 
@@ -3869,15 +4123,19 @@ x-value on the line.
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> l = linearRegressionLine(linearRegression([[<span class="hljs-number">0</span>, <span class="hljs-number">0</span>], [<span class="hljs-number">1</span>, <span class="hljs-number">1</span>]]));
-l(<span class="hljs-number">0</span>) <span class="hljs-comment">// = 0</span>
-l(<span class="hljs-number">2</span>) <span class="hljs-comment">// = 2</span>
-linearRegressionLine({ <span class="hljs-attr">b</span>: <span class="hljs-number">0</span>, <span class="hljs-attr">m</span>: <span class="hljs-number">1</span> })(<span class="hljs-number">1</span>); <span class="hljs-comment">// =&gt; 1</span>
-linearRegressionLine({ <span class="hljs-attr">b</span>: <span class="hljs-number">1</span>, <span class="hljs-attr">m</span>: <span class="hljs-number">1</span> })(<span class="hljs-number">1</span>); <span class="hljs-comment">// =&gt; 2</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> l = <span class="hljs-title function_">linearRegressionLine</span>(<span class="hljs-title function_">linearRegression</span>([[<span class="hljs-number">0</span>, <span class="hljs-number">0</span>], [<span class="hljs-number">1</span>, <span class="hljs-number">1</span>]]));
+<span class="hljs-title function_">l</span>(<span class="hljs-number">0</span>) <span class="hljs-comment">// = 0</span>
+<span class="hljs-title function_">l</span>(<span class="hljs-number">2</span>) <span class="hljs-comment">// = 2</span>
+<span class="hljs-title function_">linearRegressionLine</span>({ <span class="hljs-attr">b</span>: <span class="hljs-number">0</span>, <span class="hljs-attr">m</span>: <span class="hljs-number">1</span> })(<span class="hljs-number">1</span>); <span class="hljs-comment">// =&gt; 1</span>
+<span class="hljs-title function_">linearRegressionLine</span>({ <span class="hljs-attr">b</span>: <span class="hljs-number">1</span>, <span class="hljs-attr">m</span>: <span class="hljs-number">1</span> })(<span class="hljs-number">1</span>); <span class="hljs-comment">// =&gt; 2</span></pre>
     
+  
+
   
 
   
@@ -3898,14 +4156,12 @@ linearRegressionLine({ <span class="hljs-attr">b</span>: <span class="hljs-numbe
 
   
     
-
   
-</section>
-</div>
+</section></div>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -3923,8 +4179,7 @@ is a fast way to create a random permutation of a finite set. This is
 a function around <code>shuffle_in_place</code> that adds the guarantee that
 it will not modify its input.</p>
 
-
-  <div class='pre p1 fill-light mt0'>shuffle(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>, randomSource: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a></div>
+    <div class='pre p1 fill-light mt0'>shuffle(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>, randomSource: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a></div>
   
   
 
@@ -3977,12 +4232,16 @@ returns numbers between 0 inclusive and 1 exclusive: the range [0, 1)
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> shuffled = shuffle([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>]);
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> shuffled = <span class="hljs-title function_">shuffle</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>]);
 shuffled; <span class="hljs-comment">// = [2, 3, 1, 4] or any other random permutation</span></pre>
     
+  
+
   
 
   
@@ -3995,7 +4254,7 @@ shuffled; <span class="hljs-comment">// = [2, 3, 1, 4] or any other random permu
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -4014,8 +4273,7 @@ array by reference</strong>.</p>
 <p>This is an algorithm that generates a random <a href="https://en.wikipedia.org/wiki/Permutation">permutation</a>
 of a set.</p>
 
-
-  <div class='pre p1 fill-light mt0'>shuffleInPlace(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>, randomSource: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a></div>
+    <div class='pre p1 fill-light mt0'>shuffleInPlace(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>, randomSource: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a></div>
   
   
 
@@ -4068,13 +4326,17 @@ returns numbers between 0 inclusive and 1 exclusive: the range [0, 1)
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> x = [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>];
-shuffleInPlace(x);
+<span class="hljs-title function_">shuffleInPlace</span>(x);
 <span class="hljs-comment">// x is shuffled to a value like [2, 1, 4, 3]</span></pre>
     
+  
+
   
 
   
@@ -4087,7 +4349,7 @@ shuffleInPlace(x);
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -4103,8 +4365,7 @@ shuffleInPlace(x);
   <p>Sampling with replacement is a type of sampling that allows the same
 item to be picked out of a population more than once.</p>
 
-
-  <div class='pre p1 fill-light mt0'>sampleWithReplacement(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;any>, n: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, randomSource: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a></div>
+    <div class='pre p1 fill-light mt0'>sampleWithReplacement(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;any>, n: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, randomSource: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a></div>
   
   
 
@@ -4166,12 +4427,16 @@ returns numbers between 0 inclusive and 1 exclusive: the range [0, 1)
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> values = [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>];
-sampleWithReplacement(values, <span class="hljs-number">2</span>); <span class="hljs-comment">// returns 2 random values, like [2, 4];</span></pre>
+<span class="hljs-title function_">sampleWithReplacement</span>(values, <span class="hljs-number">2</span>); <span class="hljs-comment">// returns 2 random values, like [2, 4];</span></pre>
     
+  
+
   
 
   
@@ -4184,7 +4449,7 @@ sampleWithReplacement(values, <span class="hljs-number">2</span>); <span class="
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -4202,8 +4467,7 @@ from a given array of <code>n</code> elements.</p>
 <p>The sampled values will be in any order, not necessarily the order
 they appear in the input.</p>
 
-
-  <div class='pre p1 fill-light mt0'>sample(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;any>, n: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, randomSource: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a></div>
+    <div class='pre p1 fill-light mt0'>sample(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;any>, n: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, randomSource: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a></div>
   
   
 
@@ -4265,12 +4529,16 @@ returns numbers between 0 inclusive and 1 exclusive: the range [0, 1)
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> values = [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">6</span>, <span class="hljs-number">7</span>, <span class="hljs-number">8</span>, <span class="hljs-number">9</span>];
-sample(values, <span class="hljs-number">3</span>); <span class="hljs-comment">// returns 3 random values, like [2, 5, 8];</span></pre>
+<span class="hljs-title function_">sample</span>(values, <span class="hljs-number">3</span>); <span class="hljs-comment">// returns 3 random values, like [2, 5, 8];</span></pre>
     
+  
+
   
 
   
@@ -4291,14 +4559,12 @@ sample(values, <span class="hljs-number">3</span>); <span class="hljs-comment">/
 
   
     
-
   
-</section>
-</div>
+</section></div>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -4315,8 +4581,7 @@ sample(values, <span class="hljs-number">3</span>); <span class="hljs-comment">/
 <p>This is a naïve bayesian classifier that takes
 singly-nested objects.</p>
 
-
-  <div class='pre p1 fill-light mt0'>new BayesianClassifier()</div>
+    <div class='pre p1 fill-light mt0'>new BayesianClassifier()</div>
   
   
 
@@ -4325,6 +4590,8 @@ singly-nested objects.</p>
   
   
   
+  
+
   
 
   
@@ -4339,12 +4606,12 @@ singly-nested objects.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> bayes = <span class="hljs-keyword">new</span> BayesianClassifier();
-bayes.train({
-  <span class="hljs-attr">species</span>: <span class="hljs-string">'Cat'</span>
-}, <span class="hljs-string">'animal'</span>);
-<span class="hljs-keyword">var</span> result = bayes.score({
-  <span class="hljs-attr">species</span>: <span class="hljs-string">'Cat'</span>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> bayes = <span class="hljs-keyword">new</span> <span class="hljs-title class_">BayesianClassifier</span>();
+bayes.<span class="hljs-title function_">train</span>({
+  <span class="hljs-attr">species</span>: <span class="hljs-string">&#x27;Cat&#x27;</span>
+}, <span class="hljs-string">&#x27;animal&#x27;</span>);
+<span class="hljs-keyword">var</span> result = bayes.<span class="hljs-title function_">score</span>({
+  <span class="hljs-attr">species</span>: <span class="hljs-string">&#x27;Cat&#x27;</span>
 })
 <span class="hljs-comment">// result</span>
 <span class="hljs-comment">// {</span>
@@ -4374,8 +4641,7 @@ bayes.train({
   <p>Train the classifier with a new item, which has a single
 dimension of Javascript literal keys and values.</p>
 
-
-  <div class='pre p1 fill-light mt0'>train(item: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, category: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a></div>
+    <div class='pre p1 fill-light mt0'>train(item: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, category: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a></div>
   
   
 
@@ -4432,6 +4698,10 @@ dimension of Javascript literal keys and values.</p>
   
 
   
+
+  
+
+  
 </section>
 
       </div>
@@ -4452,8 +4722,7 @@ dimension of Javascript literal keys and values.</p>
   <p>Generate a score of how well this item matches all
 possible categories based on its attributes</p>
 
-
-  <div class='pre p1 fill-light mt0'>score(item: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
+    <div class='pre p1 fill-light mt0'>score(item: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -4502,6 +4771,10 @@ given category.
   
 
   
+
+  
+
+  
 </section>
 
       </div>
@@ -4512,12 +4785,14 @@ given category.
   
 
   
+
+  
 </section>
 
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -4534,8 +4809,7 @@ given category.
 arrays of numbers and predicts whether they should be classified
 as either 0 or 1 (negative or positive examples).</p>
 
-
-  <div class='pre p1 fill-light mt0'>new PerceptronModel()</div>
+    <div class='pre p1 fill-light mt0'>new PerceptronModel()</div>
   
   
 
@@ -4544,6 +4818,8 @@ as either 0 or 1 (negative or positive examples).</p>
   
   
   
+  
+
   
 
   
@@ -4559,18 +4835,18 @@ as either 0 or 1 (negative or positive examples).</p>
     
       
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Create the model</span>
-<span class="hljs-keyword">var</span> p = <span class="hljs-keyword">new</span> PerceptronModel();
+<span class="hljs-keyword">var</span> p = <span class="hljs-keyword">new</span> <span class="hljs-title class_">PerceptronModel</span>();
 <span class="hljs-comment">// Train the model with input with a diagonal boundary.</span>
 <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>; i &lt; <span class="hljs-number">5</span>; i++) {
-    p.train([<span class="hljs-number">1</span>, <span class="hljs-number">1</span>], <span class="hljs-number">1</span>);
-    p.train([<span class="hljs-number">0</span>, <span class="hljs-number">1</span>], <span class="hljs-number">0</span>);
-    p.train([<span class="hljs-number">1</span>, <span class="hljs-number">0</span>], <span class="hljs-number">0</span>);
-    p.train([<span class="hljs-number">0</span>, <span class="hljs-number">0</span>], <span class="hljs-number">0</span>);
+    p.<span class="hljs-title function_">train</span>([<span class="hljs-number">1</span>, <span class="hljs-number">1</span>], <span class="hljs-number">1</span>);
+    p.<span class="hljs-title function_">train</span>([<span class="hljs-number">0</span>, <span class="hljs-number">1</span>], <span class="hljs-number">0</span>);
+    p.<span class="hljs-title function_">train</span>([<span class="hljs-number">1</span>, <span class="hljs-number">0</span>], <span class="hljs-number">0</span>);
+    p.<span class="hljs-title function_">train</span>([<span class="hljs-number">0</span>, <span class="hljs-number">0</span>], <span class="hljs-number">0</span>);
 }
-p.predict([<span class="hljs-number">0</span>, <span class="hljs-number">0</span>]); <span class="hljs-comment">// 0</span>
-p.predict([<span class="hljs-number">0</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// 0</span>
-p.predict([<span class="hljs-number">1</span>, <span class="hljs-number">0</span>]); <span class="hljs-comment">// 0</span>
-p.predict([<span class="hljs-number">1</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// 1</span></pre>
+p.<span class="hljs-title function_">predict</span>([<span class="hljs-number">0</span>, <span class="hljs-number">0</span>]); <span class="hljs-comment">// 0</span>
+p.<span class="hljs-title function_">predict</span>([<span class="hljs-number">0</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// 0</span>
+p.<span class="hljs-title function_">predict</span>([<span class="hljs-number">1</span>, <span class="hljs-number">0</span>]); <span class="hljs-comment">// 0</span>
+p.<span class="hljs-title function_">predict</span>([<span class="hljs-number">1</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// 1</span></pre>
     
   
 
@@ -4595,8 +4871,7 @@ p.predict([<span class="hljs-number">1</span>, <span class="hljs-number">1</span
   <p><strong>Predict</strong>: Use an array of features with the weight array and bias
 to predict whether an example is labeled 0 or 1.</p>
 
-
-  <div class='pre p1 fill-light mt0'>predict(features: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>predict(features: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -4644,6 +4919,10 @@ to predict whether an example is labeled 0 or 1.</p>
   
 
   
+
+  
+
+  
 </section>
 
       </div>
@@ -4664,8 +4943,7 @@ to predict whether an example is labeled 0 or 1.</p>
   <p><strong>Train</strong> the classifier with a new example, which is
 a numeric array of features and a 0 or 1 label.</p>
 
-
-  <div class='pre p1 fill-light mt0'>train(features: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, label: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="#perceptronmodel">PerceptronModel</a></div>
+    <div class='pre p1 fill-light mt0'>train(features: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, label: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="#perceptronmodel">PerceptronModel</a></div>
   
   
 
@@ -4722,12 +5000,18 @@ a numeric array of features and a 0 or 1 label.</p>
   
 
   
+
+  
+
+  
 </section>
 
       </div>
     </div>
   
 </div>
+
+  
 
   
 
@@ -4745,14 +5029,12 @@ a numeric array of features and a 0 or 1 label.</p>
 
   
     
-
   
-</section>
-</div>
+</section></div>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -4775,8 +5057,7 @@ to mean "tails" (or vice versa). It is
 a special case of a Binomial Distribution
 where <code>n</code> = 1.</p>
 
-
-  <div class='pre p1 fill-light mt0'>bernoulliDistribution(p: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>></div>
+    <div class='pre p1 fill-light mt0'>bernoulliDistribution(p: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>></div>
   
   
 
@@ -4816,6 +5097,8 @@ where <code>n</code> = 1.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
@@ -4829,8 +5112,10 @@ where <code>n</code> = 1.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>bernoulliDistribution(<span class="hljs-number">0.3</span>); <span class="hljs-comment">// =&gt; [0.7, 0.3]</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">bernoulliDistribution</span>(<span class="hljs-number">0.3</span>); <span class="hljs-comment">// =&gt; [0.7, 0.3]</span></pre>
     
+  
+
   
 
   
@@ -4843,7 +5128,7 @@ where <code>n</code> = 1.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -4861,8 +5146,7 @@ distribution of the number of successes in a sequence of n independent yes/no ex
 success with probability <code>probability</code>. Such a success/failure experiment is also called a Bernoulli experiment or
 Bernoulli trial; when trials = 1, the Binomial Distribution is a Bernoulli Distribution.</p>
 
-
-  <div class='pre p1 fill-light mt0'>binomialDistribution(trials: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, probability: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>></div>
+    <div class='pre p1 fill-light mt0'>binomialDistribution(trials: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, probability: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>></div>
   
   
 
@@ -4918,12 +5202,16 @@ Bernoulli trial; when trials = 1, the Binomial Distribution is a Bernoulli Distr
   
 
   
+
+  
+
+  
 </section>
 
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -4944,8 +5232,7 @@ independently of the time since the last event.</p>
 <p>The Poisson Distribution is characterized by the strictly positive
 mean arrival or occurrence rate, <code>λ</code>.</p>
 
-
-  <div class='pre p1 fill-light mt0'>poissonDistribution(lambda: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>></div>
+    <div class='pre p1 fill-light mt0'>poissonDistribution(lambda: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>></div>
   
   
 
@@ -4993,12 +5280,16 @@ mean arrival or occurrence rate, <code>λ</code>.</p>
   
 
   
+
+  
+
+  
 </section>
 
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -5019,8 +5310,7 @@ deviation of a normal distribution from a sample standard deviation.</p>
 <p>Values from Appendix 1, Table III of William W. Hines &#x26; Douglas C. Montgomery, "Probability and Statistics in
 Engineering and Management Science", Wiley (1980).</p>
 
-
-  <div class='pre p1 fill-light mt0'>chiSquaredDistributionTable</div>
+    <div class='pre p1 fill-light mt0'>chiSquaredDistributionTable</div>
   
   
 
@@ -5029,6 +5319,10 @@ Engineering and Management Science", Wiley (1980).</p>
   
   
   
+  
+
+  
+
   
 
   
@@ -5051,7 +5345,7 @@ Engineering and Management Science", Wiley (1980).</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -5066,17 +5360,12 @@ Engineering and Management Science", Wiley (1980).</p>
 
   <p>A standard normal table, also called the unit normal table or Z table,
 is a mathematical table for the values of Φ (phi), which are the values of
-the cumulative distribution function of the normal distribution.
-It is used to find the probability that a statistic is observed below,
-above, or between values on the standard normal distribution, and by
-extension, any normal distribution.</p>
-<p>The probabilities are calculated using the
-<a href="https://en.wikipedia.org/wiki/Normal_distribution#Cumulative_distribution_function">Cumulative distribution function</a>.
-The table used is the cumulative, and not cumulative from 0 to mean
-(even though the latter has 5 digits precision, instead of 4).</p>
+the <a href="https://en.wikipedia.org/wiki/Normal_distribution#Cumulative_distribution_function">cumulative distribution function</a>
+of the normal distribution. It is used to find the probability that a
+statistic is observed below, above, or between values on the standard
+normal distribution, and by extension, any normal distribution.</p>
 
-
-  <div class='pre p1 fill-light mt0'>standardNormalTable</div>
+    <div class='pre p1 fill-light mt0'>standardNormalTable</div>
   
   
 
@@ -5085,6 +5374,10 @@ The table used is the cumulative, and not cumulative from 0 to mean
   
   
   
+  
+
+  
+
   
 
   
@@ -5107,7 +5400,7 @@ The table used is the cumulative, and not cumulative from 0 to mean
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -5124,13 +5417,12 @@ The table used is the cumulative, and not cumulative from 0 to mean
 of a sample to a known value, x.</p>
 <p>in this case, we're trying to determine whether the
 population mean is equal to the value that we know, which is <code>x</code>
-here. usually the results here are used to look up a
+here. Usually the results here are used to look up a
 <a href="http://en.wikipedia.org/wiki/P-value">p-value</a>, which, for
 a certain level of significance, will let you determine that the
 null hypothesis can or cannot be rejected.</p>
 
-
-  <div class='pre p1 fill-light mt0'>tTest(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, expectedValue: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>tTest(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, expectedValue: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -5181,11 +5473,15 @@ null hypothesis can or cannot be rejected.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>tTest([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">6</span>], <span class="hljs-number">3.385</span>).toFixed(<span class="hljs-number">2</span>); <span class="hljs-comment">// =&gt; '0.16'</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">tTest</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">6</span>], <span class="hljs-number">3.385</span>).<span class="hljs-title function_">toFixed</span>(<span class="hljs-number">2</span>); <span class="hljs-comment">// =&gt; &#x27;0.16&#x27;</span></pre>
     
+  
+
   
 
   
@@ -5198,7 +5494,7 @@ null hypothesis can or cannot be rejected.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -5222,12 +5518,11 @@ other than the fact that they have the same standard deviation.</p>
 a certain level of significance, will let you determine that the
 null hypothesis can or cannot be rejected.</p>
 <p><code>diff</code> can be omitted if it equals 0.</p>
-<p><a href="http://www.monarchlab.org/Lab/Research/Stats/2SampleT.aspx">This is used to confirm or deny</a>
+<p><a href="https://en.wikipedia.org/wiki/Exclusion_of_the_null_hypothesis">This is used to reject</a>
 a null hypothesis that the two populations that have been sampled into
 <code>sampleX</code> and <code>sampleY</code> are equal to each other.</p>
 
-
-  <div class='pre p1 fill-light mt0'>tTestTwoSample(sampleX: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, sampleY: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, difference: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | null)</div>
+    <div class='pre p1 fill-light mt0'>tTestTwoSample(sampleX: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, sampleY: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, difference: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | null)</div>
   
   
 
@@ -5287,11 +5582,15 @@ a null hypothesis that the two populations that have been sampled into
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>tTestTwoSample([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>], [<span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">6</span>], <span class="hljs-number">0</span>); <span class="hljs-comment">// =&gt; -2.1908902300206643</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">tTestTwoSample</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>], [<span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">6</span>], <span class="hljs-number">0</span>); <span class="hljs-comment">// =&gt; -2.1908902300206643</span></pre>
     
+  
+
   
 
   
@@ -5304,7 +5603,7 @@ a null hypothesis that the two populations that have been sampled into
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -5325,8 +5624,7 @@ standard normal and then use the standard normal table to find probabilities.</p
 <p>You can use <code>.5 + .5 * errorFunction(x / Math.sqrt(2))</code> to calculate the probability
 instead of looking it up in a table.</p>
 
-
-  <div class='pre p1 fill-light mt0'>cumulativeStdNormalProbability(z: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>cumulativeStdNormalProbability(z: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -5373,12 +5671,16 @@ instead of looking it up in a table.</p>
   
 
   
+
+  
+
+  
 </section>
 
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -5395,8 +5697,7 @@ instead of looking it up in a table.</p>
 is a useful tool for, among other things, estimating the shape of the
 underlying probability distribution from a sample.</p>
 
-
-  <div class='pre p1 fill-light mt0'>kernelDensityEstimation</div>
+    <div class='pre p1 fill-light mt0'>kernelDensityEstimation</div>
   
   
 
@@ -5468,6 +5769,10 @@ underlying probability distribution from a sample.</p>
   
 
   
+
+  
+
+  
 </section>
 
           
@@ -5481,14 +5786,12 @@ underlying probability distribution from a sample.</p>
 
   
     
-
   
-</section>
-</div>
+</section></div>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -5504,10 +5807,10 @@ underlying probability distribution from a sample.</p>
   <p><strong><a href="http://en.wikipedia.org/wiki/Error_function">Gaussian error function</a></strong></p>
 <p>The <code>errorFunction(x/(sd * Math.sqrt(2)))</code> is the probability that a value in a
 normal distribution with standard deviation sd is within x of the mean.</p>
-<p>This function returns a numerical approximation to the exact value.</p>
+<p>This function returns a numerical approximation to the exact value.
+It uses Horner's method to evaluate the polynomial of τ (tau).</p>
 
-
-  <div class='pre p1 fill-light mt0'>errorFunction(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>errorFunction(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -5549,11 +5852,15 @@ normal distribution with standard deviation sd is within x of the mean.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>errorFunction(<span class="hljs-number">1</span>).toFixed(<span class="hljs-number">2</span>); <span class="hljs-comment">// =&gt; '0.84'</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">errorFunction</span>(<span class="hljs-number">1</span>).<span class="hljs-title function_">toFixed</span>(<span class="hljs-number">2</span>); <span class="hljs-comment">// =&gt; &#x27;0.84&#x27;</span></pre>
     
+  
+
   
 
   
@@ -5566,7 +5873,7 @@ normal distribution with standard deviation sd is within x of the mean.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -5583,8 +5890,7 @@ normal distribution with standard deviation sd is within x of the mean.</p>
 returns a numerical approximation to the value that would have caused
 <code>errorFunction()</code> to return x.</p>
 
-
-  <div class='pre p1 fill-light mt0'>inverseErrorFunction(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>inverseErrorFunction(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -5632,12 +5938,16 @@ returns a numerical approximation to the value that would have caused
   
 
   
+
+  
+
+  
 </section>
 
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -5658,8 +5968,7 @@ where the p'th quantile of values can be found in a normal distribution.
 So, for example, probit(0.5 + 0.6827/2) ≈ 1 because 68.27% of values are
 normally found within 1 standard deviation above or below the mean.</p>
 
-
-  <div class='pre p1 fill-light mt0'>probit(p: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>probit(p: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -5706,6 +6015,10 @@ normally found within 1 standard deviation above or below the mean.</p>
   
 
   
+
+  
+
+  
 </section>
 
           
@@ -5724,12 +6037,11 @@ breaks that splits data evenly can make for a better choropleth map,
 for instance, because each color will be represented equally.</p>
 
   
-</section>
-</div>
+</section></div>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -5768,8 +6080,7 @@ provided.</p>
 Programming</em> Haizhou Wang and Mingzhou Song ISSN 2073-4859</p>
 <p>from The R Journal Vol. 3/2, December 2011</p>
 
-
-  <div class='pre p1 fill-light mt0'>ckmeans(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, nClusters: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>></div>
+    <div class='pre p1 fill-light mt0'>ckmeans(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, nClusters: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>></div>
   
   
 
@@ -5819,6 +6130,8 @@ greater than the number of values in the data array.
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
@@ -5832,10 +6145,12 @@ greater than the number of values in the data array.
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>ckmeans([<span class="hljs-number">-1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">-1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">6</span>, <span class="hljs-number">-1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">-1</span>], <span class="hljs-number">3</span>);
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">ckmeans</span>([-<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, -<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">6</span>, -<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, -<span class="hljs-number">1</span>], <span class="hljs-number">3</span>);
 <span class="hljs-comment">// The input, clustered into groups of similar numbers.</span>
 <span class="hljs-comment">//= [[-1, -1, -1, -1], [2, 2, 2], [4, 5, 6]]);</span></pre>
     
+  
+
   
 
   
@@ -5848,7 +6163,7 @@ greater than the number of values in the data array.
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -5867,8 +6182,7 @@ to categorize the x into a number of classes. The
 returned array will always be 1 longer than the number of
 classes because it includes the minimum value.</p>
 
-
-  <div class='pre p1 fill-light mt0'>equalIntervalBreaks(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, nClasses: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>></div>
+    <div class='pre p1 fill-light mt0'>equalIntervalBreaks(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, nClasses: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>></div>
   
   
 
@@ -5919,11 +6233,15 @@ classes because it includes the minimum value.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>equalIntervalBreaks([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">6</span>], <span class="hljs-number">4</span>); <span class="hljs-comment">// =&gt; [1, 2.25, 3.5, 4.75, 6]</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">equalIntervalBreaks</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">6</span>], <span class="hljs-number">4</span>); <span class="hljs-comment">// =&gt; [1, 2.25, 3.5, 4.75, 6]</span></pre>
     
+  
+
   
 
   
@@ -5944,14 +6262,12 @@ classes because it includes the minimum value.</p>
 
   
     
-
   
-</section>
-</div>
+</section></div>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -5971,8 +6287,7 @@ the input size is not divisible by the chunk size.</p>
 <p><code>x</code> is expected to be an array, and <code>chunkSize</code> a number.
 The <code>x</code> array can contain any kind of data.</p>
 
-
-  <div class='pre p1 fill-light mt0'>chunk(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>, chunkSize: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>></div>
+    <div class='pre p1 fill-light mt0'>chunk(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>, chunkSize: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>></div>
   
   
 
@@ -6021,6 +6336,8 @@ The <code>x</code> array can contain any kind of data.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
@@ -6034,9 +6351,11 @@ The <code>x</code> array can contain any kind of data.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>chunk([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">6</span>], <span class="hljs-number">2</span>);
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">chunk</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>, <span class="hljs-number">6</span>], <span class="hljs-number">2</span>);
 <span class="hljs-comment">// =&gt; [[1, 2], [3, 4], [5, 6]]</span></pre>
     
+  
+
   
 
   
@@ -6049,7 +6368,7 @@ The <code>x</code> array can contain any kind of data.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -6071,8 +6390,7 @@ takes the total number of observed frequencies and subtracts the number of estim
 follows, approximately, a chi-square distribution with (k − c) degrees of freedom where <code>k</code> is the number of non-empty
 cells and <code>c</code> is the number of estimated parameters for the distribution.</p>
 
-
-  <div class='pre p1 fill-light mt0'>chiSquaredGoodnessOfFit(data: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, distributionType: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>, significance: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>chiSquaredGoodnessOfFit(data: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, distributionType: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>, significance: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -6131,11 +6449,13 @@ for instance, binomial, bernoulli, or poisson
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Data from Poisson goodness-of-fit example 10-19 in William W. Hines &amp; Douglas C. Montgomery,</span>
-<span class="hljs-comment">// "Probability and Statistics in Engineering and Management Science", Wiley (1980).</span>
+<span class="hljs-comment">// &quot;Probability and Statistics in Engineering and Management Science&quot;, Wiley (1980).</span>
 <span class="hljs-keyword">var</span> data1019 = [
     <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>,
     <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>,
@@ -6143,8 +6463,10 @@ for instance, binomial, bernoulli, or poisson
     <span class="hljs-number">2</span>, <span class="hljs-number">2</span>, <span class="hljs-number">2</span>, <span class="hljs-number">2</span>, <span class="hljs-number">2</span>, <span class="hljs-number">2</span>, <span class="hljs-number">2</span>, <span class="hljs-number">2</span>, <span class="hljs-number">2</span>,
     <span class="hljs-number">3</span>, <span class="hljs-number">3</span>, <span class="hljs-number">3</span>, <span class="hljs-number">3</span>
 ];
-ss.chiSquaredGoodnessOfFit(data1019, ss.poissonDistribution, <span class="hljs-number">0.05</span>); <span class="hljs-comment">//= false</span></pre>
+ss.<span class="hljs-title function_">chiSquaredGoodnessOfFit</span>(data1019, ss.<span class="hljs-property">poissonDistribution</span>, <span class="hljs-number">0.05</span>); <span class="hljs-comment">//= false</span></pre>
     
+  
+
   
 
   
@@ -6157,7 +6479,7 @@ ss.chiSquaredGoodnessOfFit(data1019, ss.poissonDistribution, <span class="hljs-n
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -6180,8 +6502,12 @@ it progresses until it is close enough.</p>
 where we're trying to find a local minimum of a function's derivative,
 given by the <code>fDerivative</code> method.</p>
 
-
-  <div class='pre p1 fill-light mt0'>epsilon</div>
+    <div class='pre p1 fill-light mt0'>epsilon</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
+    </p>
   
   
 
@@ -6190,6 +6516,8 @@ given by the <code>fDerivative</code> method.</p>
   
   
   
+  
+
   
 
   
@@ -6210,20 +6538,22 @@ given by the <code>fDerivative</code> method.</p>
 <span class="hljs-keyword">var</span> x_new = <span class="hljs-number">6</span>;
 <span class="hljs-keyword">var</span> stepSize = <span class="hljs-number">0.01</span>;
 
-<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">fDerivative</span>(<span class="hljs-params">x</span>) </span>{
-  <span class="hljs-keyword">return</span> <span class="hljs-number">4</span> * <span class="hljs-built_in">Math</span>.pow(x, <span class="hljs-number">3</span>) - <span class="hljs-number">9</span> * <span class="hljs-built_in">Math</span>.pow(x, <span class="hljs-number">2</span>);
+<span class="hljs-keyword">function</span> <span class="hljs-title function_">fDerivative</span>(<span class="hljs-params">x</span>) {
+  <span class="hljs-keyword">return</span> <span class="hljs-number">4</span> * <span class="hljs-title class_">Math</span>.<span class="hljs-title function_">pow</span>(x, <span class="hljs-number">3</span>) - <span class="hljs-number">9</span> * <span class="hljs-title class_">Math</span>.<span class="hljs-title function_">pow</span>(x, <span class="hljs-number">2</span>);
 }
 
 <span class="hljs-comment">// The loop runs until the difference between the previous</span>
 <span class="hljs-comment">// value and the current value is smaller than epsilon - a rough</span>
-<span class="hljs-comment">// meaure of 'close enough'</span>
-<span class="hljs-keyword">while</span> (<span class="hljs-built_in">Math</span>.abs(x_new - x_old) &gt; ss.epsilon) {
+<span class="hljs-comment">// meaure of &#x27;close enough&#x27;</span>
+<span class="hljs-keyword">while</span> (<span class="hljs-title class_">Math</span>.<span class="hljs-title function_">abs</span>(x_new - x_old) &gt; ss.<span class="hljs-property">epsilon</span>) {
   x_old = x_new;
-  x_new = x_old - stepSize * fDerivative(x_old);
+  x_new = x_old - stepSize * <span class="hljs-title function_">fDerivative</span>(x_old);
 }
 
-<span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Local minimum occurs at'</span>, x_new);</pre>
+<span class="hljs-variable language_">console</span>.<span class="hljs-title function_">log</span>(<span class="hljs-string">&#x27;Local minimum occurs at&#x27;</span>, x_new);</pre>
     
+  
+
   
 
   
@@ -6236,7 +6566,7 @@ given by the <code>fDerivative</code> method.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -6254,8 +6584,7 @@ integers less than or equal to n. Often factorial is implemented
 recursively, but this iterative approach is significantly faster
 and simpler.</p>
 
-
-  <div class='pre p1 fill-light mt0'>factorial(n: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>factorial(n: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -6295,6 +6624,8 @@ and simpler.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
@@ -6308,8 +6639,10 @@ and simpler.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>factorial(<span class="hljs-number">5</span>); <span class="hljs-comment">// =&gt; 120</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">factorial</span>(<span class="hljs-number">5</span>); <span class="hljs-comment">// =&gt; 120</span></pre>
     
+  
+
   
 
   
@@ -6322,7 +6655,7 @@ and simpler.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -6342,8 +6675,7 @@ though this implementation currently does not handle complex numbers as input va
 Nemes' approximation is defined <a href="https://arxiv.org/abs/1003.6020">here</a> as Theorem 2.2.
 Negative values use <a href="https://en.wikipedia.org/wiki/Gamma_function#Properties">Euler's reflection formula</a> for computation.</p>
 
-
-  <div class='pre p1 fill-light mt0'>gamma(n: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>gamma(n: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -6385,13 +6717,17 @@ Negative values use <a href="https://en.wikipedia.org/wiki/Gamma_function#Proper
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>gamma(<span class="hljs-number">11.5</span>); <span class="hljs-comment">// 11899423.084037038</span>
-gamma(<span class="hljs-number">-11.5</span>); <span class="hljs-comment">// 2.29575810481609e-8 </span>
-gamma(<span class="hljs-number">5</span>); <span class="hljs-comment">// 24</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">gamma</span>(<span class="hljs-number">11.5</span>); <span class="hljs-comment">// 11899423.084037038</span>
+<span class="hljs-title function_">gamma</span>(-<span class="hljs-number">11.5</span>); <span class="hljs-comment">// 2.29575810481609e-8</span>
+<span class="hljs-title function_">gamma</span>(<span class="hljs-number">5</span>); <span class="hljs-comment">// 24</span></pre>
     
+  
+
   
 
   
@@ -6404,7 +6740,7 @@ gamma(<span class="hljs-number">5</span>); <span class="hljs-comment">// 24</spa
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -6423,8 +6759,7 @@ a simple implementation of the algorithm.</p>
 <p>Values are compared with <code>===</code>, so objects and non-primitive objects
 are not handled in any special way.</p>
 
-
-  <div class='pre p1 fill-light mt0'>uniqueCountSorted(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;any>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>uniqueCountSorted(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;any>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -6466,12 +6801,16 @@ are not handled in any special way.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>uniqueCountSorted([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]); <span class="hljs-comment">// =&gt; 3</span>
-uniqueCountSorted([<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// =&gt; 1</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">uniqueCountSorted</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]); <span class="hljs-comment">// =&gt; 3</span>
+<span class="hljs-title function_">uniqueCountSorted</span>([<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-number">1</span>]); <span class="hljs-comment">// =&gt; 1</span></pre>
     
+  
+
   
 
   
@@ -6484,7 +6823,98 @@ uniqueCountSorted([<span class="hljs-number">1</span>, <span class="hljs-number"
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='approxequal'>
+      approxEqual
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Approximate equality.</p>
+
+    <div class='pre p1 fill-light mt0'>approxEqual(actual: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, expected: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, tolerance: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>actual</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+	    The value to be tested.
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>expected</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+	    The reference value.
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>tolerance</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
+            = <code>epsilon</code>)</code>
+	    The acceptable relative difference.
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></code>:
+        Whether numbers are within tolerance.
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -6501,8 +6931,7 @@ uniqueCountSorted([<span class="hljs-number">1</span>, <span class="hljs-number"
 method that repeatedly bisects an interval to find the root.</p>
 <p>This function returns a numerical approximation to the exact value.</p>
 
-
-  <div class='pre p1 fill-light mt0'>bisect(func: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>, start: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, end: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, maxIterations: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, errorTolerance: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>bisect(func: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>, start: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, end: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, maxIterations: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, errorTolerance: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -6578,6 +7007,8 @@ method that repeatedly bisects an interval to find the root.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
@@ -6591,8 +7022,10 @@ method that repeatedly bisects an interval to find the root.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>bisect(<span class="hljs-built_in">Math</span>.cos,<span class="hljs-number">0</span>,<span class="hljs-number">4</span>,<span class="hljs-number">100</span>,<span class="hljs-number">0.003</span>); <span class="hljs-comment">// =&gt; 1.572265625</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">bisect</span>(<span class="hljs-title class_">Math</span>.<span class="hljs-property">cos</span>,<span class="hljs-number">0</span>,<span class="hljs-number">4</span>,<span class="hljs-number">100</span>,<span class="hljs-number">0.003</span>); <span class="hljs-comment">// =&gt; 1.572265625</span></pre>
     
+  
+
   
 
   
@@ -6605,7 +7038,88 @@ method that repeatedly bisects an interval to find the root.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='coefficientofvariation'>
+      coefficientOfVariation
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>The<code>coefficient of variation</code>_ is the ratio of the standard deviation to the mean.
+.._<code>coefficient of variation</code>: <a href="https://en.wikipedia.org/wiki/Coefficient_of_variation">https://en.wikipedia.org/wiki/Coefficient_of_variation</a></p>
+
+    <div class='pre p1 fill-light mt0'>coefficientOfVariation(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>x</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>)</code>
+	    input
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>:
+        coefficient of variation
+
+      
+    
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">coefficientOfVariation</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>]).<span class="hljs-title function_">toFixed</span>(<span class="hljs-number">3</span>); <span class="hljs-comment">// =&gt; 0.516</span>
+<span class="hljs-title function_">coefficientOfVariation</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>]).<span class="hljs-title function_">toFixed</span>(<span class="hljs-number">3</span>); <span class="hljs-comment">// =&gt; 0.527</span>
+<span class="hljs-title function_">coefficientOfVariation</span>([-<span class="hljs-number">1</span>, <span class="hljs-number">0</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>]).<span class="hljs-title function_">toFixed</span>(<span class="hljs-number">3</span>); <span class="hljs-comment">// =&gt; 1.247</span></pre>
+    
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -6623,8 +7137,7 @@ Combinations are unique subsets of a collection - in this case, k x from a colle
 'With replacement' means that a given element can be chosen multiple times.
 Unlike permutation, order doesn't matter for combinations.</p>
 
-
-  <div class='pre p1 fill-light mt0'>combinationsReplacement(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>, k: int): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>></div>
+    <div class='pre p1 fill-light mt0'>combinationsReplacement(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>, k: int): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>></div>
   
   
 
@@ -6675,11 +7188,15 @@ Unlike permutation, order doesn't matter for combinations.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>combinationsReplacement([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>], <span class="hljs-number">2</span>); <span class="hljs-comment">// =&gt; [[1, 1], [1, 2], [2, 2]]</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">combinationsReplacement</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>], <span class="hljs-number">2</span>); <span class="hljs-comment">// =&gt; [[1, 1], [1, 2], [2, 2]]</span></pre>
     
+  
+
   
 
   
@@ -6692,7 +7209,7 @@ Unlike permutation, order doesn't matter for combinations.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -6709,8 +7226,7 @@ Unlike permutation, order doesn't matter for combinations.</p>
 Combinations are unique subsets of a collection - in this case, k x from a collection at a time.
 <a href="https://en.wikipedia.org/wiki/Combination">https://en.wikipedia.org/wiki/Combination</a></p>
 
-
-  <div class='pre p1 fill-light mt0'>combinations(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>, k: int): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>></div>
+    <div class='pre p1 fill-light mt0'>combinations(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>, k: int): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>></div>
   
   
 
@@ -6761,11 +7277,15 @@ Combinations are unique subsets of a collection - in this case, k x from a colle
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>combinations([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>], <span class="hljs-number">2</span>); <span class="hljs-comment">// =&gt; [[1,2], [1,3], [2,3]]</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">combinations</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>], <span class="hljs-number">2</span>); <span class="hljs-comment">// =&gt; [[1,2], [1,3], [2,3]]</span></pre>
     
+  
+
   
 
   
@@ -6778,7 +7298,7 @@ Combinations are unique subsets of a collection - in this case, k x from a colle
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -6797,8 +7317,7 @@ linear time. They can instead use this function to compute the combined
 mean by providing the mean &#x26; number of values of the first list and the mean
 &#x26; number of values of the second list.</p>
 
-
-  <div class='pre p1 fill-light mt0'>combineMeans(mean1: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, n1: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, mean2: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, n2: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>combineMeans(mean1: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, n1: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, mean2: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, n2: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -6867,11 +7386,15 @@ mean by providing the mean &#x26; number of values of the first list and the mea
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>combineMeans(<span class="hljs-number">5</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">3</span>); <span class="hljs-comment">// =&gt; 4.5</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">combineMeans</span>(<span class="hljs-number">5</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">3</span>); <span class="hljs-comment">// =&gt; 4.5</span></pre>
     
+  
+
   
 
   
@@ -6884,7 +7407,7 @@ mean by providing the mean &#x26; number of values of the first list and the mea
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -6903,8 +7426,7 @@ in linear time. They can instead use this function to compute the combined
 variance by providing the variance, mean &#x26; number of values of the first list
 and the variance, mean &#x26; number of values of the second list.</p>
 
-
-  <div class='pre p1 fill-light mt0'>combineVariances(variance1: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, mean1: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, n1: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, variance2: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, mean2: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, n2: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>combineVariances(variance1: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, mean1: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, n1: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, variance2: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, mean2: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, n2: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -6991,11 +7513,15 @@ and the variance, mean &#x26; number of values of the second list.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>combineVariances(<span class="hljs-number">14</span> / <span class="hljs-number">3</span>, <span class="hljs-number">5</span>, <span class="hljs-number">3</span>, <span class="hljs-number">8</span> / <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">3</span>); <span class="hljs-comment">// =&gt; 47 / 12</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">combineVariances</span>(<span class="hljs-number">14</span> / <span class="hljs-number">3</span>, <span class="hljs-number">5</span>, <span class="hljs-number">3</span>, <span class="hljs-number">8</span> / <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">3</span>); <span class="hljs-comment">// =&gt; 47 / 12</span></pre>
     
+  
+
   
 
   
@@ -7008,7 +7534,159 @@ and the variance, mean &#x26; number of values of the second list.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='cumulativestdlogisticprobability'>
+      cumulativeStdLogisticProbability
+    </h3>
+    
+    
+  </div>
+  
+
+  <p><strong><a href="https://en.wikipedia.org/wiki/Logistic_distribution">Logistic Cumulative Distribution Function</a></strong></p>
+
+    <div class='pre p1 fill-light mt0'>cumulativeStdLogisticProbability(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>x</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>:
+        cumulative standard logistic probability
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='euclideandistance'>
+      euclideanDistance
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Calculate Euclidean distance between two points.</p>
+
+    <div class='pre p1 fill-light mt0'>euclideanDistance(left: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, right: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>left</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>)</code>
+	    First N-dimensional point.
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>right</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>)</code>
+	    Second N-dimensional point.
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>:
+        Distance.
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -7025,8 +7703,7 @@ and the variance, mean &#x26; number of values of the second list.</p>
 the first element in the array is always the lowest while the last element is always the largest, so this calculation
 can be done in one step, or constant time.</p>
 
-
-  <div class='pre p1 fill-light mt0'>extentSorted(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>></div>
+    <div class='pre p1 fill-light mt0'>extentSorted(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>></div>
   
   
 
@@ -7068,11 +7745,15 @@ can be done in one step, or constant time.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>extentSorted([<span class="hljs-number">-100</span>, <span class="hljs-number">-10</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">5</span>]); <span class="hljs-comment">// =&gt; [-100, 5]</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">extentSorted</span>([-<span class="hljs-number">100</span>, -<span class="hljs-number">10</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">5</span>]); <span class="hljs-comment">// =&gt; [-100, 5]</span></pre>
     
+  
+
   
 
   
@@ -7085,7 +7766,7 @@ can be done in one step, or constant time.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -7099,10 +7780,9 @@ can be done in one step, or constant time.</p>
   
 
   <p>This computes the minimum &#x26; maximum number in an array.</p>
-<p>This runs on <code>O(n)</code>, linear time in respect to the array</p>
+<p>This runs in <code>O(n)</code>, linear time, with respect to the length of the array.</p>
 
-
-  <div class='pre p1 fill-light mt0'>extent(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>></div>
+    <div class='pre p1 fill-light mt0'>extent(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>></div>
   
   
 
@@ -7142,10 +7822,12 @@ can be done in one step, or constant time.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
-        <li><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>: if the the length of x is less than one
+        <li><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>: if the length of x is less than one
 </li>
       
     </ul>
@@ -7155,9 +7837,11 @@ can be done in one step, or constant time.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>extent([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>]);
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">extent</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>]);
 <span class="hljs-comment">// =&gt; [1, 4]</span></pre>
     
+  
+
   
 
   
@@ -7170,7 +7854,608 @@ can be done in one step, or constant time.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='gammaln'>
+      gammaln
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Compute the logarithm of the <a href="https://en.wikipedia.org/wiki/Gamma_function">gamma function</a> of a value using Lanczos' approximation.
+This function takes as input any real-value n greater than 0.
+This function is useful for values of n too large for the normal gamma function (n > 165).
+The code is based on Lanczo's Gamma approximation, defined <a href="http://my.fit.edu/~gabdo/gamma.txt">here</a>.</p>
+
+    <div class='pre p1 fill-light mt0'>gammaln(n: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>n</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+	    Any real number greater than zero.
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>:
+        The logarithm of gamma of the input value.
+
+      
+    
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">gammaln</span>(<span class="hljs-number">500</span>); <span class="hljs-comment">// 2605.1158503617335</span>
+<span class="hljs-title function_">gammaln</span>(<span class="hljs-number">2.4</span>); <span class="hljs-comment">// 0.21685932244884043</span></pre>
+    
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='jenks'>
+      jenks
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>The <strong><a href="http://en.wikipedia.org/wiki/Jenks_natural_breaks_optimization">jenks natural breaks optimization</a></strong>
+is an algorithm commonly used in cartography and visualization to decide
+upon groupings of data values that minimize variance within themselves
+and maximize variation between themselves.</p>
+<p>For instance, cartographers often use jenks in order to choose which
+values are assigned to which colors in a <a href="https://en.wikipedia.org/wiki/Choropleth_map">choropleth</a>
+map.</p>
+
+    <div class='pre p1 fill-light mt0'>jenks(data: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, nClasses: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>data</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>)</code>
+	    input data, as an array of number values
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>nClasses</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+	    number of desired classes
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>></code>:
+        array of class break positions
+// split data into 3 break points
+jenks([1, 2, 4, 5, 7, 9, 10, 20], 3) // = [1, 7, 20, 20]
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='kmeansreturn'>
+      kMeansReturn
+    </h3>
+    
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>kMeansReturn</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>labels</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>)</code>
+          : The labels.
+
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>centroids</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>>)</code>
+          : The cluster centroids.
+
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='kmeanscluster'>
+      kMeansCluster
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Perform k-means clustering.</p>
+
+    <div class='pre p1 fill-light mt0'>kMeansCluster(points: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>>, numCluster: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, randomSource: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>): <a href="#kmeansreturn">kMeansReturn</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>points</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>>)</code>
+	    N-dimensional coordinates of points to be clustered.
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>numCluster</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+	    How many clusters to create.
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>randomSource</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>
+            = <code>Math.random</code>)</code>
+	    An optional entropy source that generates uniform values in [0, 1).
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="#kmeansreturn">kMeansReturn</a></code>:
+        Labels (same length as data) and centroids (same length as numCluster).
+
+      
+    
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Throws</div>
+    <ul>
+      
+        <li><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>: If any centroids wind up friendless (i.e., without associated points).
+</li>
+      
+    </ul>
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">kMeansCluster</span>([[<span class="hljs-number">0.0</span>, <span class="hljs-number">0.5</span>], [<span class="hljs-number">1.0</span>, <span class="hljs-number">0.5</span>]], <span class="hljs-number">2</span>); <span class="hljs-comment">// =&gt; {labels: [0, 1], centroids: [[0.0, 0.5], [1.0 0.5]]}</span></pre>
+    
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='logaverage'>
+      logAverage
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>The <a href="https://en.wikipedia.org/wiki/https://en.wikipedia.org/wiki/Geometric_mean#Relationship_with_logarithms">log average</a>
+is an equivalent way of computing the geometric mean of an array suitable for large or small products.</p>
+<p>It's found by calculating the average logarithm of the elements and exponentiating.</p>
+
+    <div class='pre p1 fill-light mt0'>logAverage(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>x</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>)</code>
+	    sample of one or more data points
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>:
+        geometric mean
+
+      
+    
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Throws</div>
+    <ul>
+      
+        <li><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>: if x is empty
+</li>
+      
+        <li><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>: if x contains a negative number
+</li>
+      
+    </ul>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='logit'>
+      logit
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>The <a href="https://en.wikipedia.org/wiki/Logit">Logit</a>
+is the inverse of cumulativeStdLogisticProbability,
+and is also known as the logistic quantile function.</p>
+
+    <div class='pre p1 fill-light mt0'>logit(p: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>p</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>:
+        logit
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='meansimple'>
+      meanSimple
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>The mean, <em>also known as average</em>,
+is the sum of all values over the number of values.
+This is a <a href="https://en.wikipedia.org/wiki/Central_tendency">measure of central tendency</a>:
+a method of finding a typical or central value of a set of numbers.</p>
+<p>The simple mean uses the successive addition method internally
+to calculate it's result. Errors in floating-point addition are
+not accounted for, so if precision is required, the standard <a href="#mean">mean</a>
+method should be used instead.</p>
+<p>This runs in <code>O(n)</code>, linear time, with respect to the length of the array.</p>
+
+    <div class='pre p1 fill-light mt0'>meanSimple(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>x</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>)</code>
+	    sample of one or more data points
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>:
+        mean
+
+      
+    
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Throws</div>
+    <ul>
+      
+        <li><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>: if the length of x is less than one
+</li>
+      
+    </ul>
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">mean</span>([<span class="hljs-number">0</span>, <span class="hljs-number">10</span>]); <span class="hljs-comment">// =&gt; 5</span></pre>
+    
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -7194,8 +8479,7 @@ The function allows for the following hypotheses:</p>
 <a href="https://en.wikipedia.org/wiki/One-_and_two-tailed_tests">Learn more about one-tail vs two-tail tests.</a></li>
 </ul>
 
-
-  <div class='pre p1 fill-light mt0'>permutationTest(sampleX: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, sampleY: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, alternative: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, k: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>permutationTest(sampleX: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, sampleY: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, alternative: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, k: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, randomSource: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -7246,6 +8530,16 @@ The function allows for the following hypotheses:</p>
           
         </div>
       
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>randomSource</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>
+            = <code>Math.random</code>)</code>
+	    an optional entropy source
+
+          </div>
+          
+        </div>
+      
     </div>
   
 
@@ -7264,13 +8558,17 @@ The function allows for the following hypotheses:</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> control = [<span class="hljs-number">2</span>, <span class="hljs-number">5</span>, <span class="hljs-number">3</span>, <span class="hljs-number">6</span>, <span class="hljs-number">7</span>, <span class="hljs-number">2</span>, <span class="hljs-number">5</span>];
 <span class="hljs-keyword">var</span> treatment = [<span class="hljs-number">20</span>, <span class="hljs-number">5</span>, <span class="hljs-number">13</span>, <span class="hljs-number">12</span>, <span class="hljs-number">7</span>, <span class="hljs-number">2</span>, <span class="hljs-number">2</span>];
-permutationTest(control, treatment); <span class="hljs-comment">// ~0.1324</span></pre>
+<span class="hljs-title function_">permutationTest</span>(control, treatment); <span class="hljs-comment">// ~0.1324</span></pre>
     
+  
+
   
 
   
@@ -7283,7 +8581,7 @@ permutationTest(control, treatment); <span class="hljs-comment">// ~0.1324</span
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -7299,8 +8597,7 @@ permutationTest(control, treatment); <span class="hljs-comment">// ~0.1324</span
   <p>Implementation of <a href="https://en.wikipedia.org/wiki/Heap%27s_algorithm">Heap's Algorithm</a>
 for generating permutations.</p>
 
-
-  <div class='pre p1 fill-light mt0'>permutationsHeap(elements: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>></div>
+    <div class='pre p1 fill-light mt0'>permutationsHeap(elements: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>></div>
   
   
 
@@ -7348,12 +8645,16 @@ for generating permutations.</p>
   
 
   
+
+  
+
+  
 </section>
 
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -7370,8 +8671,7 @@ for generating permutations.</p>
 the given array. With a sorted array, leveraging binary search, we can find
 this information in logarithmic time.</p>
 
-
-  <div class='pre p1 fill-light mt0'>quantileRankSorted(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, value: any): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>quantileRankSorted(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, value: any): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -7421,14 +8721,18 @@ this information in logarithmic time.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>quantileRankSorted([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>], <span class="hljs-number">3</span>); <span class="hljs-comment">// =&gt; 0.75</span>
-quantileRankSorted([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>], <span class="hljs-number">3</span>); <span class="hljs-comment">// =&gt; 0.7</span>
-quantileRankSorted([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>], <span class="hljs-number">6</span>); <span class="hljs-comment">// =&gt; 1</span>
-quantileRankSorted([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">3</span>, <span class="hljs-number">5</span>], <span class="hljs-number">4</span>); <span class="hljs-comment">// =&gt; 0.8</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">quantileRankSorted</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>], <span class="hljs-number">3</span>); <span class="hljs-comment">// =&gt; 0.75</span>
+<span class="hljs-title function_">quantileRankSorted</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>], <span class="hljs-number">3</span>); <span class="hljs-comment">// =&gt; 0.7</span>
+<span class="hljs-title function_">quantileRankSorted</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>], <span class="hljs-number">6</span>); <span class="hljs-comment">// =&gt; 1</span>
+<span class="hljs-title function_">quantileRankSorted</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">3</span>, <span class="hljs-number">5</span>], <span class="hljs-number">4</span>); <span class="hljs-comment">// =&gt; 0.8</span></pre>
     
+  
+
   
 
   
@@ -7441,7 +8745,7 @@ quantileRankSorted([<span class="hljs-number">1</span>, <span class="hljs-number
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -7455,12 +8759,11 @@ quantileRankSorted([<span class="hljs-number">1</span>, <span class="hljs-number
   
 
   <p>This function returns the quantile in which one would find the given value in
-the given array. It will require to copy and sort your array beforehand, so
-if you know your array is already sorted, you would rather use
-<code>quantileRankSorted</code>.</p>
+the given array. It will copy and sort your array before each run, so
+if you know your array is already sorted, you should use <code>quantileRankSorted</code>
+instead.</p>
 
-
-  <div class='pre p1 fill-light mt0'>quantileRank(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, value: any): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>quantileRank(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, value: any): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -7510,14 +8813,18 @@ if you know your array is already sorted, you would rather use
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>quantileRank([<span class="hljs-number">4</span>, <span class="hljs-number">3</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>], <span class="hljs-number">3</span>); <span class="hljs-comment">// =&gt; 0.75</span>
-quantileRank([<span class="hljs-number">4</span>, <span class="hljs-number">3</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">1</span>], <span class="hljs-number">3</span>); <span class="hljs-comment">// =&gt; 0.7</span>
-quantileRank([<span class="hljs-number">2</span>, <span class="hljs-number">4</span>, <span class="hljs-number">1</span>, <span class="hljs-number">3</span>], <span class="hljs-number">6</span>); <span class="hljs-comment">// =&gt; 1</span>
-quantileRank([<span class="hljs-number">5</span>, <span class="hljs-number">3</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>], <span class="hljs-number">4</span>); <span class="hljs-comment">// =&gt; 0.8</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">quantileRank</span>([<span class="hljs-number">4</span>, <span class="hljs-number">3</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>], <span class="hljs-number">3</span>); <span class="hljs-comment">// =&gt; 0.75</span>
+<span class="hljs-title function_">quantileRank</span>([<span class="hljs-number">4</span>, <span class="hljs-number">3</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">1</span>], <span class="hljs-number">3</span>); <span class="hljs-comment">// =&gt; 0.7</span>
+<span class="hljs-title function_">quantileRank</span>([<span class="hljs-number">2</span>, <span class="hljs-number">4</span>, <span class="hljs-number">1</span>, <span class="hljs-number">3</span>], <span class="hljs-number">6</span>); <span class="hljs-comment">// =&gt; 1</span>
+<span class="hljs-title function_">quantileRank</span>([<span class="hljs-number">5</span>, <span class="hljs-number">3</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>], <span class="hljs-number">4</span>); <span class="hljs-comment">// =&gt; 0.8</span></pre>
     
+  
+
   
 
   
@@ -7530,7 +8837,7 @@ quantileRank([<span class="hljs-number">5</span>, <span class="hljs-number">3</s
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -7547,8 +8854,7 @@ quantileRank([<span class="hljs-number">5</span>, <span class="hljs-number">3</s
 The <code>k</code>-th element will have the <code>(k - left + 1)</code>-th smallest value in <code>[left, right]</code>.</p>
 <p>Implements Floyd-Rivest selection algorithm <a href="https://en.wikipedia.org/wiki/Floyd-Rivest_algorithm">https://en.wikipedia.org/wiki/Floyd-Rivest_algorithm</a></p>
 
-
-  <div class='pre p1 fill-light mt0'>quickselect(arr: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, k: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, left: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?, right: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?): void</div>
+    <div class='pre p1 fill-light mt0'>quickselect(arr: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, k: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, left: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?, right: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?): void</div>
   
   
 
@@ -7617,13 +8923,17 @@ The <code>k</code>-th element will have the <code>(k - left + 1)</code>-th small
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> arr = [<span class="hljs-number">65</span>, <span class="hljs-number">28</span>, <span class="hljs-number">59</span>, <span class="hljs-number">33</span>, <span class="hljs-number">21</span>, <span class="hljs-number">56</span>, <span class="hljs-number">22</span>, <span class="hljs-number">95</span>, <span class="hljs-number">50</span>, <span class="hljs-number">12</span>, <span class="hljs-number">90</span>, <span class="hljs-number">53</span>, <span class="hljs-number">28</span>, <span class="hljs-number">77</span>, <span class="hljs-number">39</span>];
-quickselect(arr, <span class="hljs-number">8</span>);
+<span class="hljs-title function_">quickselect</span>(arr, <span class="hljs-number">8</span>);
 <span class="hljs-comment">// = [39, 28, 28, 33, 21, 12, 22, 50, 53, 56, 59, 65, 90, 77, 95]</span></pre>
     
+  
+
   
 
   
@@ -7636,7 +8946,115 @@ quickselect(arr, <span class="hljs-number">8</span>);
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='relativeerror'>
+      relativeError
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Relative error.</p>
+<p>This is more difficult to calculate than it first appears [1,2].  The usual
+formula for the relative error between an actual value A and an expected
+value E is <code>|(A-E)/E|</code>, but:</p>
+<ol>
+<li>
+<p>If the expected value is 0, any other value has infinite relative error,
+which is counter-intuitive: if the expected voltage is 0, getting 1/10th
+of a volt doesn't feel like an infinitely large error.</p>
+</li>
+<li>
+<p>This formula does not satisfy the mathematical definition of a metric [3].
+[4] solved this problem by defining the relative error as <code>|ln(|A/E|)|</code>,
+but that formula only works if all values are positive: for example, it
+reports the relative error of -10 and 10 as 0.</p>
+</li>
+</ol>
+<p>Our implementation sticks with convention and returns:</p>
+<ul>
+<li>0 if the actual and expected values are both zero</li>
+<li>Infinity if the actual value is non-zero and the expected value is zero</li>
+<li><code>|(A-E)/E|</code> in all other cases</li>
+</ul>
+<p>[1] <a href="https://math.stackexchange.com/questions/677852/how-to-calculate-relative-error-when-true-value-is-zero">https://math.stackexchange.com/questions/677852/how-to-calculate-relative-error-when-true-value-is-zero</a>
+[2] <a href="https://en.wikipedia.org/wiki/Relative_change_and_difference">https://en.wikipedia.org/wiki/Relative_change_and_difference</a>
+[3] <a href="https://en.wikipedia.org/wiki/Metric_(mathematics)#Definition">https://en.wikipedia.org/wiki/Metric_(mathematics)#Definition</a>
+[4] F.W.J. Olver: "A New Approach to Error Arithmetic." SIAM Journal on
+Numerical Analysis, 15(2), 1978, 10.1137/0715024.</p>
+
+    <div class='pre p1 fill-light mt0'>relativeError(actual: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, expected: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>actual</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+	    The actual value.
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>expected</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+	    The expected value.
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>:
+        The relative error.
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -7656,8 +9074,7 @@ variance. The kurtosis value can be positive or negative, or even undefined.</p>
 unbiased moment estimators. This is the version found in Excel and available
 in several statistical packages, including SAS and SciPy.</p>
 
-
-  <div class='pre p1 fill-light mt0'>sampleKurtosis(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>sampleKurtosis(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -7697,6 +9114,8 @@ in several statistical packages, including SAS and SciPy.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
       
@@ -7710,8 +9129,10 @@ in several statistical packages, including SAS and SciPy.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>sampleKurtosis([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">5</span>]); <span class="hljs-comment">// =&gt; 1.4555765595463122</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">sampleKurtosis</span>([<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">5</span>]); <span class="hljs-comment">// =&gt; 1.4555765595463122</span></pre>
     
+  
+
   
 
   
@@ -7724,7 +9145,272 @@ in several statistical packages, including SAS and SciPy.</p>
           
         
           
-            <section class='p2 mb2 clearfix bg-white minishadow'>
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='samplerankcorrelation'>
+      sampleRankCorrelation
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>The <a href="https://en.wikipedia.org/wiki/Rank_correlation">rank correlation</a> is
+a measure of the strength of monotonic relationship between two arrays</p>
+
+    <div class='pre p1 fill-light mt0'>sampleRankCorrelation(x: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, y: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>x</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>)</code>
+	    first input
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>y</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>)</code>
+	    second input
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>:
+        sample rank correlation
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='silhouettemetric'>
+      silhouetteMetric
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Calculate the <a href="https://en.wikipedia.org/wiki/Silhouette_(clustering)">silhouette metric</a>
+for a set of N-dimensional points arranged in groups. The metric is the largest
+individual silhouette value for the data.</p>
+
+    <div class='pre p1 fill-light mt0'>silhouetteMetric(points: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>>, labels: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>points</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>>)</code>
+	    N-dimensional coordinates of points.
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>labels</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>)</code>
+	    Labels of points. This must be the same length as 
+<code>points</code>
+,
+and values must lie in [0..G-1], where G is the number of groups.
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>:
+        The silhouette metric for the groupings.
+
+      
+    
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">silhouetteMetric</span>([[<span class="hljs-number">0.25</span>], [<span class="hljs-number">0.75</span>]], [<span class="hljs-number">0</span>, <span class="hljs-number">0</span>]); <span class="hljs-comment">// =&gt; 1.0</span></pre>
+    
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='silhouette'>
+      silhouette
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Calculate the <a href="https://en.wikipedia.org/wiki/Silhouette_(clustering)">silhouette values</a>
+for clustered data.</p>
+
+    <div class='pre p1 fill-light mt0'>silhouette(points: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>>, labels: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>points</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>>)</code>
+	    N-dimensional coordinates of points.
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>labels</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>)</code>
+	    Labels of points. This must be the same length as 
+<code>points</code>
+,
+and values must lie in [0..G-1], where G is the number of groups.
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>></code>:
+        The silhouette value for each point.
+
+      
+    
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">silhouette</span>([[<span class="hljs-number">0.25</span>], [<span class="hljs-number">0.75</span>]], [<span class="hljs-number">0</span>, <span class="hljs-number">0</span>]); <span class="hljs-comment">// =&gt; [1.0, 1.0]</span></pre>
+    
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
 
   
   <div class='clearfix'>
@@ -7742,8 +9428,7 @@ recompute the mean of the list in linear time. They can instead use
 this function to compute the new mean by providing the current mean,
 the number of elements in the list that produced it and the value to remove.</p>
 
-
-  <div class='pre p1 fill-light mt0'>subtractFromMean(mean: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, n: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, value: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+    <div class='pre p1 fill-light mt0'>subtractFromMean(mean: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, n: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, value: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
   
   
 
@@ -7803,11 +9488,110 @@ the number of elements in the list that produced it and the value to remove.</p>
   
 
   
+
+  
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'>subtractFromMean(<span class="hljs-number">20.5</span>, <span class="hljs-number">6</span>, <span class="hljs-number">53</span>); <span class="hljs-comment">// =&gt; 14</span></pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">subtractFromMean</span>(<span class="hljs-number">20.5</span>, <span class="hljs-number">6</span>, <span class="hljs-number">53</span>); <span class="hljs-comment">// =&gt; 14</span></pre>
     
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='wilcoxonranksum'>
+      wilcoxonRankSum
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>This function calculates the Wilcoxon rank sum statistic for the first sample
+with respect to the second. The Wilcoxon rank sum test is a non-parametric
+alternative to the t-test which is equivalent to the
+<a href="https://en.wikipedia.org/wiki/Mann%E2%80%93Whitney_U_test">Mann-Whitney U test</a>.
+The statistic is calculated by pooling all the observations together, ranking them,
+and then summing the ranks associated with one of the samples. If this rank sum is
+sufficiently large or small we reject the hypothesis that the two samples come
+from the same distribution in favor of the alternative that one is shifted with
+respect to the other.</p>
+
+    <div class='pre p1 fill-light mt0'>wilcoxonRankSum(sampleX: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>, sampleY: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>sampleX</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>)</code>
+	    a sample as an array of numbers
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>sampleY</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>>)</code>
+	    a sample as an array of numbers
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>:
+        rank sum for sampleX
+
+      
+    
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-title function_">wilcoxonRankSum</span>([<span class="hljs-number">1</span>, <span class="hljs-number">4</span>, <span class="hljs-number">8</span>], [<span class="hljs-number">9</span>, <span class="hljs-number">12</span>, <span class="hljs-number">15</span>]); <span class="hljs-comment">// =&gt; 6</span></pre>
+    
+  
+
   
 
   

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "simple-statistics-docs",
-  "version": "1.0.0",
+  "version": "7.8.7",
   "description": "simple statistics documentation website",
   "main": "index.js",
   "scripts": {
     "start": "documentation watch ./simple-statistics",
-    "build": "documentation build ./simple-statistics/src/* --project-version='6.0.0' --project-name 'simple-statistics' -f html -o . -c documentation.yml"
+    "build": "documentation build ./simple-statistics/src/*.js --project-version='7.8.7' --project-name 'simple-statistics' -f html -o . -c documentation.yml"
   },
   "repository": {
     "type": "git",
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/simple-statistics/docs",
   "devDependencies": {
-    "documentation": "^6.0.0"
+    "documentation": "^14.0.3"
   }
 }


### PR DESCRIPTION
Spotted that this was 6y out of date so I've bumped the docs to the simple-statistics 7.8.7 package.

Bumped documentation.js to latest.
Build command changed to run off the .js files as the typescript type files create duplicate docs entries.
Version updated to follow the simple-statistics package number, as this is what documentation.js uses now.
All other changes result of `npm run build`

Thank you.